### PR TITLE
Define $(WARNINGS) and use it in $(CFLAGS). Add -Wno-unknown-pragmas.

### DIFF
--- a/build_linux/Makefile
+++ b/build_linux/Makefile
@@ -5,13 +5,14 @@ LKLIB = lkuxwx3.a
 
 CC = gcc
 CXX = g++
-CFLAGS = -fPIC -Wall -O2 `wx-config-3 --cflags` -I../include -I../src/freetype/include -DFT2_BUILD_LIBRARY -DOPJ_STATIC -DFT_CONFIG_MODULES_H=\"slimftmodules.h\" -DFT_CONFIG_OPTIONS_H=\"slimftoptions.h\" -I$(LKDIR)/include
+WARNINGS = -Wall -Wno-unknown-pragmas
+CFLAGS = -fPIC $(WARNINGS) -O2 `wx-config-3 --cflags` -I../include -I ../src/freetype/include -DFT2_BUILD_LIBRARY -DOPJ_STATIC -DFT_CONFIG_MODULES_H=\"slimftmodules.h\" -DFT_CONFIG_OPTIONS_H=\"slimftoptions.h\" -I $(LKDIR)/include
 CXXFLAGS = -std=c++0x $(CFLAGS)
 OBJCXXFLAGS = -std=c++0x
 
 LIBNAME = wexuxwx3
 TARGET = ../$(LIBNAME).a
-	
+
 OBJECTS = \
 	ftbase.o \
 	ftbbox.o \


### PR DESCRIPTION
It's prudent to disable GCC's unknown-pragma warnings as there are a few pragmas present in the tree for the Microsoft compiler.  We can just ignore them for the Linux build.