### PR TITLE
Reorder class member initialisations so that they are appear in declaration order

### DIFF
--- a/src/dview/dvtimeseriesdataset.cpp
+++ b/src/dview/dvtimeseriesdataset.cpp
@@ -136,7 +136,7 @@ wxDVArrayDataSet::wxDVArrayDataSet(const wxString &var, const std::vector<double
 }
 
 wxDVArrayDataSet::wxDVArrayDataSet(const wxString &var, const std::vector<wxRealPoint> &data)
-	: m_varLabel(var), m_pData(data), m_timestep(1), m_offset(0)
+	: m_varLabel(var), m_timestep(1), m_offset(0), m_pData(data)
 {
 }
 

--- a/src/lkscript.cpp
+++ b/src/lkscript.cpp
@@ -1742,8 +1742,8 @@ END_EVENT_TABLE()
 
 wxLKScriptCtrl::wxLKScriptCtrl(wxWindow *parent, int id,
 const wxPoint &pos, const wxSize &size, unsigned long libs)
-: wxCodeEditCtrl(parent, id, pos, size), m_vm(this),
-m_timer(this, IDT_TIMER)
+: wxCodeEditCtrl(parent, id, pos, size), m_timer(this, IDT_TIMER),
+  m_vm(this)
 {
 	m_syntaxCheckRequestId = m_syntaxCheckThreadId = 0;
 	Bind(wxEVT_THREAD, &wxLKScriptCtrl::OnSyntaxCheckThreadFinished, this);

--- a/src/plot/plcontourplot.cpp
+++ b/src/plot/plcontourplot.cpp
@@ -47,7 +47,7 @@ wxPLContourPlot::wxPLContourPlot(
 	const wxMatrix<double> &z,
 	bool filled,
 	const wxString &label, int levels, wxPLColourMap *cmap)
-	: wxPLPlottable(label), m_x(x), m_y(y), m_z(z), m_filled(filled), m_cmap(cmap)
+  	: wxPLPlottable(label), m_x(x), m_y(y), m_z(z), m_cmap(cmap), m_filled(filled)
 {
 	m_zMin = m_zMax = std::numeric_limits<double>::quiet_NaN();
 

--- a/src/plot/plplot.cpp
+++ b/src/plot/plplot.cpp
@@ -59,13 +59,14 @@ private:
 	double m_yPhysMin, m_yPhysMax;
 	double m_physicalConstraint;
 	wxRealPoint m_ptCenter;
-	bool m_primaryX, m_primaryY;
+	bool m_primaryY, m_primaryX;
 
 public:
 	wxPLAxisDeviceMapping(wxPLAxis *x, double xmin, double xmax, bool primaryx,
 		wxPLAxis *y, double ymin, double ymax, bool primaryy)
-		: m_xAxis(x), m_xPhysMin(xmin), m_xPhysMax(xmax), m_primaryX(primaryx),
-		m_yAxis(y), m_yPhysMin(ymin), m_yPhysMax(ymax), m_primaryY(primaryy)
+	  	: m_xAxis(x), m_xPhysMin(xmin), m_xPhysMax(xmax), m_yAxis(y),
+		  m_yPhysMin(ymin), m_yPhysMax(ymax), m_primaryY(primaryy),
+		  m_primaryX(primaryx)
 	{
 		wxRealPoint pos, size;
 		GetDeviceExtents(&pos, &size);
@@ -1074,9 +1075,9 @@ class wxPLDefaultAnnotationMapper : public wxPLAnnotationMapping
 public:
 	wxPLDefaultAnnotationMapper(wxPLAnnotation::PositionMode posmode, const wxPLRealRect &extent,
 		wxPLAxis *xx, double xmin, double xmax, wxPLAxis *yy, double ymin, double ymax)
-		: m_posMode(posmode), m_dev(extent),
-		m_xax(xx), m_xmin(xmin), m_xmax(xmax),
-		m_yax(yy), m_ymin(ymin), m_ymax(ymax)
+	  	: m_dev(extent), m_posMode(posmode),
+		m_xax(xx), m_yax(yy), m_xmin(xmin), m_xmax(xmax),
+		m_ymin(ymin), m_ymax(ymax)
 	{
 	}
 


### PR DESCRIPTION
These changes suppress -Wreorder warnings from g++.