### PR TITLE
Re-work use of 'fgets' to eliminate g++ unchecked return value warnings

### DIFF
--- a/src/dview/dvfilereader.cpp
+++ b/src/dview/dvfilereader.cpp
@@ -389,7 +389,8 @@ static bool ReadWeatherFileLine(FILE *fp, int type,
 	}
 	else if (type == WF_TM3)
 	{
-		fgets(buf, 1024, fp);
+	  	if (fgets(buf, sizeof(buf), fp) == NULL)
+			return false;
 		int ncols = cstrlocate(buf, cols, 128, ',');
 
 		if (ncols < 68)
@@ -429,7 +430,8 @@ static bool ReadWeatherFileLine(FILE *fp, int type,
 	}
 	else if (type == WF_EPW)
 	{
-		fgets(buf, 1024, fp);
+	  	if (fgets(buf, sizeof(buf), fp) == NULL)
+			return false;
 		int ncols = cstrlocate(buf, cols, 128, ',');
 
 		if (ncols < 32)

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -22,6 +22,8 @@
 *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************************************************************/
 
+#include <fstream>
+
 #include <wx/textctrl.h>
 #include <wx/stattext.h>
 #include <wx/sizer.h>
@@ -68,15 +70,15 @@ static bool GetFileRegistration(wxString *email, wxString *key)
 		first_run = false;
 
 		wxString regfile(gs_regData->GetLocalRegistrationFile());
-		if (FILE *f = fopen(regfile.c_str(), "r"))
+		std::ifstream f(regfile.c_str());
+		if (f.is_open())
 		{
-			char buf[256];
-			fgets(buf, 255, f);
-			s_email = wxString(buf).Trim().Trim(true);
-			fgets(buf, 255, f);
-			s_key = wxString(buf).Trim().Trim(true);
-			fclose(f);
-
+		  	std::string line;
+		  	getline(f, line);
+			s_email = wxString(line).Trim().Trim(true);
+		  	getline(f, line);
+			s_key = wxString(line).Trim().Trim(true);
+			f.close();
 			s_filereg = s_email.Find("@") != wxNOT_FOUND && s_key.Find("-") != wxNOT_FOUND;
 		}
 	}


### PR DESCRIPTION
In one case, it's easy to check the return value of fgets(). In the other, we use the proper C++ standard library to avoid the less safe C library functions.