### PR TITLE
Fix many signed and unsigned integer comparison warnings from g++

### DIFF
--- a/src/diurnal.cpp
+++ b/src/diurnal.cpp
@@ -422,11 +422,11 @@ char wxDiurnalPeriodCtrl::ScheduleIntToChar(int d)
 
 bool wxDiurnalPeriodCtrl::Schedule(const wxString &sched)
 {
-	if ((int)sched.Len() != m_nrows*m_ncols)
+	if (sched.Len() != m_nrows*m_ncols)
 		return false;
 
-	for (int r = 0; r < m_nrows; r++)
-		for (int c = 0; c < m_ncols; c++)
+	for (size_t r = 0; r < m_nrows; r++)
+		for (size_t c = 0; c < m_ncols; c++)
 			VALUE(r, c) = ScheduleCharToInt(sched[r*m_ncols + c]);
 
 	Refresh();
@@ -437,8 +437,8 @@ bool wxDiurnalPeriodCtrl::Schedule(const wxString &sched)
 wxString wxDiurnalPeriodCtrl::Schedule() const
 {
 	wxString buf;
-	for (int r = 0; r < m_nrows; r++)
-		for (int c = 0; c < m_ncols; c++)
+	for (size_t r = 0; r < m_nrows; r++)
+		for (size_t c = 0; c < m_ncols; c++)
 			buf << ScheduleIntToChar(VALUE(r, c));
 
 	return buf;
@@ -470,9 +470,9 @@ void wxDiurnalPeriodCtrl::Copy()
 		// This data objects are held by the clipboard,
 		// so do not delete them in the app.
 		wxString tsv;
-		for (int r = 0; r < m_nrows; r++)
+		for (size_t r = 0; r < m_nrows; r++)
 		{
-			for (int c = 0; c < m_ncols; c++)
+			for (size_t c = 0; c < m_ncols; c++)
 			{
 				tsv += wxString::Format("%d", VALUE(r, c));
 				if (c < m_ncols - 1)
@@ -497,9 +497,9 @@ void wxDiurnalPeriodCtrl::Paste()
 		if (as.Count() >= (m_nrows * m_ncols))
 		{
 			int as_ndx = 0;
-			for (int r = 0; r < m_nrows; r++)
+			for (size_t r = 0; r < m_nrows; r++)
 			{
-				for (int c = 0; c < m_ncols; c++)
+				for (size_t c = 0; c < m_ncols; c++)
 				{
 					long val = 0;
 					if (as_ndx < (int)as.Count())
@@ -557,17 +557,17 @@ bool wxDiurnalPeriodCtrl::MSWShouldPreProcessMessage(WXMSG* msg)
 
 void wxDiurnalPeriodCtrl::OnChar(wxKeyEvent &evt)
 {
-	int selrs = MIN(m_selStartR, m_selEndR);
-	int selcs = MIN(m_selStartC, m_selEndC);
-	int selre = MAX(m_selStartR, m_selEndR);
-	int selce = MAX(m_selStartC, m_selEndC);
+	size_t selrs = MIN(m_selStartR, m_selEndR);
+	size_t selcs = MIN(m_selStartC, m_selEndC);
+	size_t selre = MAX(m_selStartR, m_selEndR);
+	size_t selce = MAX(m_selStartC, m_selEndC);
 
 	int key = evt.GetKeyCode();
 	if ((ScheduleCharToInt(key) >= m_min) && (ScheduleCharToInt(key) <= m_max) &&
 		selrs >= 0 && selcs >= 0)
 	{
-		for (int r = selrs; r <= selre && r < m_nrows; r++)
-			for (int c = selcs; c <= selce && c < m_ncols; c++)
+		for (size_t r = selrs; r <= selre && r < m_nrows; r++)
+			for (size_t c = selcs; c <= selce && c < m_ncols; c++)
 				VALUE(r, c) = ScheduleCharToInt(key);
 
 		Refresh();
@@ -583,8 +583,8 @@ void wxDiurnalPeriodCtrl::OnMouseDown(wxMouseEvent &evt)
 	m_selStartC = (evt.GetX() - m_rowHeaderSize) / m_cellSize;
 	m_selStartR = (evt.GetY() - m_colHeaderSize) / m_cellSize;
 
-	if (m_selStartC < 0 || m_selStartC >= m_ncols ||
-		m_selStartR < 0 || m_selStartR >= m_nrows ||
+	if (m_selStartC < 0 || m_selStartC >= static_cast<int>(m_ncols) ||
+	    m_selStartR < 0 || m_selStartR >= static_cast<int>(m_nrows) ||
 		evt.GetX() < m_rowHeaderSize || evt.GetY() < m_colHeaderSize)
 	{
 		m_selStartC = m_selStartR = -1;
@@ -611,8 +611,8 @@ void wxDiurnalPeriodCtrl::OnMouseMove(wxMouseEvent &evt)
 	int c = (evt.GetX() - m_rowHeaderSize) / m_cellSize;
 	int r = (evt.GetY() - m_colHeaderSize) / m_cellSize;
 
-	if (r >= 0 && r < m_nrows &&
-		c >= 0 && c < m_ncols)
+	if (r >= 0 && r < static_cast<int>(m_nrows) &&
+	    c >= 0 && c < static_cast<int>(m_ncols))
 	{
 		m_selEndR = r;
 		m_selEndC = c;

--- a/src/lkscript.cpp
+++ b/src/lkscript.cpp
@@ -2382,7 +2382,7 @@ bool wxLKScriptCtrl::Debug(int mode)
 	// always update the view.
 	m_debugger->UpdateView();
 
-	if (ip < (int)dbg.size())
+	if (ip < dbg.size())
 	{
 		ShowLineArrow(dbg[ip].stmt - 1);
 

--- a/src/metro.cpp
+++ b/src/metro.cpp
@@ -1103,7 +1103,7 @@ int wxMetroNotebook::GetPageIndex(wxWindow *win)
 
 wxWindow *wxMetroNotebook::RemovePage(size_t ndx)
 {
-	if (ndx < 0 || ndx >= (int)m_pages.size())
+	if (ndx < 0 || ndx >= m_pages.size())
 		return 0;
 
 	wxWindow *win = GetPage(ndx);
@@ -1154,7 +1154,7 @@ int wxMetroNotebook::GetSelection() const
 
 void wxMetroNotebook::SetText(size_t id, const wxString &text)
 {
-	if ((id < (int)m_pages.size()) && (id >= 0))
+	if ((id < m_pages.size()) && (id >= 0))
 	{
 		m_pages[id].text = text;
 		UpdateTabList();
@@ -1163,7 +1163,7 @@ void wxMetroNotebook::SetText(size_t id, const wxString &text)
 
 wxString wxMetroNotebook::GetText(size_t id) const
 {
-	if (id < (int)m_pages.size() && id >= 0)
+	if (id < m_pages.size() && id >= 0)
 		return m_pages[id].text;
 	else
 		return wxEmptyString;

--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -395,7 +395,7 @@ double wxPLLinearAxis::DetermineLargeTickStep(double physical_len, bool &should_
 	double mantissa = pow(10.0, log10(approxTickStep) - exponent);
 
 	// determine next whole mantissa below the approx one.
-	size_t mantissaIndex = m_mantissas.size() - 1;
+	ssize_t mantissaIndex = m_mantissas.size() - 1;
 	for (size_t i = 1; i < m_mantissas.size(); ++i)
 	{
 		if (mantissa < m_mantissas[i])
@@ -407,7 +407,7 @@ double wxPLLinearAxis::DetermineLargeTickStep(double physical_len, bool &should_
 
 	// then choose next largest spacing.
 	mantissaIndex += 1;
-	if (mantissaIndex == m_mantissas.size())
+	if (mantissaIndex == static_cast<ssize_t>(m_mantissas.size()))
 	{
 		mantissaIndex = 0;
 		exponent += 1.0;


### PR DESCRIPTION
In most cases, these were fixed by removing unnecessary casts. The natural type of wxWidget's size() and other methods is size_t, which is unsigned. So in most cases, casts to int were causing the warnings unnecessarily. In one case, I used static_cast<>.