### PR TITLE
Guard static variable declarations with wxUSE_LOG_TRACE and wxDEBUG_LEVEL

### DIFF
--- a/src/jsonreader.cpp
+++ b/src/jsonreader.cpp
@@ -162,8 +162,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxUSE_LOG_TRACE
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
+#endif
 
 //! Ctor
 /*!

--- a/src/jsonval.cpp
+++ b/src/jsonval.cpp
@@ -23,11 +23,13 @@
 
 WX_DEFINE_OBJARRAY(wxJSONInternalArray);
 
+#if wxUSE_LOG_TRACE
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = wxT("jsonval");
 static const wxChar* traceMask = wxT("jsonval");
 static const wxChar* compareTraceMask = wxT("sameas");
 static const wxChar* cowTraceMask = wxT("traceCOW");
+#endif
 
 double json_double(const wxJSONValue &jv, double defaultval, bool *Exists)
 {

--- a/src/jsonwriter.cpp
+++ b/src/jsonwriter.cpp
@@ -19,7 +19,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxUSE_LOG_TRACE
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer

--- a/src/pdf/pdfdc.cpp
+++ b/src/pdf/pdfdc.cpp
@@ -610,7 +610,10 @@ wxPdfDCImpl::DoDrawSpline(const wxPointList* points)
   wxCHECK_RET(m_pdfDocument, wxT("Invalid PDF DC"));
   SetPen( m_pen );
   wxASSERT_MSG( points, wxT("NULL pointer to spline points?") );
+#if wxDEBUG_LEVEL > 0
+  /* only define n_points if assertions are on */
   const size_t n_points = points->GetCount();
+#endif
   wxASSERT_MSG( n_points > 2 , wxT("incomplete list of spline points?") );
 #if 0
   wxPoint* p;


### PR DESCRIPTION
Using these wxWidgets macros to prevent these static variables being defined unless using wxWidgets
logging and/or debugging. Without this, the wx logging and debugging macros expand to nothing and so the variables produce unused variable warnings.