### PR TITLE
Fix warning about loss of constness.

### DIFF
--- a/src/plot/plcontourplot.cpp
+++ b/src/plot/plcontourplot.cpp
@@ -466,7 +466,8 @@ static bool qhull_delaunay(int npoints, const double* x, const double* y,
 	/* Perform Delaunay triangulation. */
 	/* qhull expects a FILE* to write errors to, use stderr */
 	exitcode = qh_new_qhull(ndim, npoints, points, False,
-		"qhull d Qt Qbb Qc Qz", NULL, stderr);
+				const_cast<char *>("qhull d Qt Qbb Qc Qz"),
+				NULL, stderr);
 	if (exitcode != qh_ERRnone) {
 		fprintf(stderr,
 			"Error in qhull Delaunay triangulation calculation: %s (exitcode=%d)",


### PR DESCRIPTION
`libqhull` is a C library being called from the C++ source base. It's a nightmare fixing all of the use of string literals throughout the library, so the easiest thing to do is use a `const_cast` on entry to the library. I think that is a reasonable approach.