### PR TITLE
Makefile (OBJECTS): Add ftlcdfil.o.

### DIFF
--- a/build_linux/Makefile
+++ b/build_linux/Makefile
@@ -21,6 +21,7 @@ OBJECTS = \
 	ftgasp.o \
 	ftglyph.o \
 	ftinit.o \
+	ftlcdfil.o \
 	ftstroke.o \
 	ftsynth.o \
 	ftsystem.o \


### PR DESCRIPTION
I am not completely sure why others can build on Linux without this patch. Without it, `ltlcdfil.o` isn't built which means `FT_Library_SetLcdFilter` isn't defined. Anyway, this seems to fix a lot of issues for me!