### PR TITLE
Handle missing data by replacing with 0 and warning user

### DIFF
--- a/src/dview/dvfilereader.cpp
+++ b/src/dview/dvfilereader.cpp
@@ -44,10 +44,13 @@
 #include <wx/tokenzr.h>
 #include <wx/txtstrm.h>
 #include <wx/wfstream.h>
+#include <wx/dialog.h>
+
 
 #include "wex/dview/dvfilereader.h"
 #include "wex/dview/dvplotctrl.h"
 #include "wex/dview/dvtimeseriesdataset.h"
+#include "wex/utils.h"
 
 
 vector<tuple<string, string, double> > m_unitConversions;
@@ -713,6 +716,15 @@ bool wxDVFileReader::FastRead(wxDVPlotCtrl *plotWin, const wxString& filename, i
 			if (strlen(dblbuf) > 0)
 			{
 				dataSets[ncol]->Append(wxRealPoint(timeCounters[ncol], atof(dblbuf))); // convert number and add data point.
+				timeCounters[ncol] += dataSets[ncol]->GetTimeStep();
+			}
+			// in event that data is missing, what to do?  For now, set to 0
+			else
+			{
+				wxString message; 
+				message.Printf(wxT("Column '%s' contains missing data!\nReplacing missing data with 0's, please correct your file"), dataSets[ncol]->GetSeriesTitle());
+				wxShowTextMessageDialog(message, wxEmptyString, plotWin, wxSize(400,150));
+				dataSets[ncol]->Append(wxRealPoint(timeCounters[ncol], 0));
 				timeCounters[ncol] += dataSets[ncol]->GetTimeStep();
 			}
 			if (*p) p++; // skip the comma or delimiter


### PR DESCRIPTION
Fixes #41 .You can test the behavior on the attached file.  I've simple removed data for each of the columns in the first or second row.  It will go through all columns and alert the user if data is missing in that column.  If all columns are missing data, this could be burdensome, but might be good to alert user.  Alternate could be to implement more complex dialog with a "Yes to all" or something.

[MissingDataExample.zip](https://github.com/NREL/wex/files/1518908/MissingDataExample.zip)

https://www.pivotaltracker.com/story/show/153268630