### PR TITLE
* src/pdf/pdffontparsertruetype.cpp (tableNamesDefault): Remove.

### DIFF
--- a/src/pdf/pdffontparsertruetype.cpp
+++ b/src/pdf/pdffontparsertruetype.cpp
@@ -459,12 +459,6 @@ wxPdfFontParserTrueType::ClearTableDirectory()
   }
 }
 
-static const wxChar* tableNamesDefault[] = {
-  wxT("cvt "), wxT("fpgm"), wxT("glyf"), wxT("head"),
-  wxT("hhea"), wxT("hmtx"), wxT("loca"), wxT("maxp"), wxT("prep"),
-  NULL
-};
-
 void
 wxPdfFontParserTrueType::LockTable(const wxString& tableName)
 {


### PR DESCRIPTION
This is not needed -- it's an unused static variable. This change has already been accepted upstream: utelle/wxpdfdoc@8991cecb7671f481b261c9f685ec729b8f071e31