### PR TITLE
Fix an assortment of remaining warnings.

### DIFF
--- a/include/wex/dview/dvpncdfctrl.h
+++ b/include/wex/dview/dvpncdfctrl.h
@@ -89,7 +89,6 @@ private:
 	int m_selectedDataSetIndex;
 	std::vector< std::vector<wxRealPoint>* > m_cdfPlotData; //We track cdf plots since they take long to calculate.
 
-	wxTextCtrl *m_minTextBox;
 	wxTextCtrl *m_maxTextBox;
 
 	wxDVSelectionListCtrl *m_selector;

--- a/include/wex/dview/dvstatisticstablectrl.h
+++ b/include/wex/dview/dvstatisticstablectrl.h
@@ -170,7 +170,6 @@ private:
 	std::vector<wxDVVariableStatistics*> m_variableStatistics;
 	wxDataViewCtrl *m_ctrl;
 	wxObjectDataPtr<dvStatisticsTreeModel> m_StatisticsModel;
-	wxDataViewColumn* m_col;
 	wxMenu m_contextMenu;
 	wxCheckBox *m_chkShowMonths;
 	bool m_showMonths;

--- a/include/wex/lkscript.h
+++ b/include/wex/lkscript.h
@@ -150,7 +150,6 @@ private:
 
 	bool m_scriptRunning;
 	bool m_stopScriptFlag;
-	wxWindow *m_topLevelWindow;
 	wxLKDebugger *m_debugger;
 	bool m_debuggerFirstShow;
 

--- a/include/wex/pdf/pdfcffdecoder.h
+++ b/include/wex/pdf/pdfcffdecoder.h
@@ -113,8 +113,6 @@ protected:
   int CalcHints(wxInputStream* stream, int begin, int end, int globalBias, int localBias, wxPdfCffIndexArray& localSubIndex);
 
 private:
-  wxInputStream*        m_stream;              ///< the input stream
-
   wxPdfCffIndexArray*   m_globalSubrIndex;     ///< index of the global subroutines
 
   int                   m_charstringType;      ///< charstring type (distinguishes type 1 and type 2 font formats)
@@ -123,7 +121,6 @@ private:
   wxPdfCffFontObject*   m_args;                ///< argument stack
   int                   m_argCount;            ///< argument count
 
-  int                   m_globalBias;          ///< The bias for the global subroutines
   int                   m_numHints;            ///< Number of arguments to the stem operators in a subroutine calculated recursively
 
   wxPdfSortedArrayInt*  m_hGlobalSubrsUsed;    ///< A HashMap for keeping the Global subroutines used in the font

--- a/include/wex/pdf/pdfcffdecoder.h
+++ b/include/wex/pdf/pdfcffdecoder.h
@@ -24,6 +24,10 @@
 #include "wex/pdf/pdfarraytypes.h"
 #include "wex/pdf/pdfcffindex.h"
 
+const int NUM_STD_STRINGS = 391;
+
+const char SUBR_RETURN_OP = 11;
+
 // Forward declaration of internal classes
 class wxPdfCffFontObject;
 

--- a/include/wex/pdf/pdffontsubsetcff.h
+++ b/include/wex/pdf/pdffontsubsetcff.h
@@ -280,7 +280,6 @@ private:
   wxArrayInt            m_privateDictOffset;       ///< offsets in private dictionary
 
   int                   m_globalBias;              ///< The bias for the global subroutines
-  int                   m_numHints;                ///< Number of arguments to the stem operators in a subroutine calculated recursively
 
   wxPdfSortedArrayInt*  m_hGlobalSubrsUsed;        ///< A HashMap for keeping the Global subroutines used in the font
   wxArrayInt            m_lGlobalSubrsUsed;        ///< The Global SubroutinesUsed HashMaps as ArrayLists

--- a/include/wex/pdf/pdfpattern.h
+++ b/include/wex/pdf/pdfpattern.h
@@ -65,10 +65,6 @@ private:
 
   double m_width;      ///< pattern width
   double m_height;     ///< pattern height
-  
-  double m_xStep;      ///< repeat offset in x direction
-  double m_yStep;      ///< repeat offset in y direction
-  double m_matrix[6];  ///< transformation matrix
 };
 
 #if 0

--- a/include/wex/pdf/pdfshape.h
+++ b/include/wex/pdf/pdfshape.h
@@ -93,7 +93,6 @@ private:
   wxPdfArrayDouble m_x;       ///< array of abscissa values
   wxPdfArrayDouble m_y;       ///< array of ordinate values
   int              m_subpath; ///< subpath index
-  int              m_segment; ///< segment index
   int              m_index;   ///< points index
 };
 

--- a/include/wex/pdf/pdfxml.h
+++ b/include/wex/pdf/pdfxml.h
@@ -315,7 +315,6 @@ private:
   wxPdfDoubleHashMap m_rowHeights;   ///< array of row heights
   wxPdfDoubleHashMap m_colWidths;    ///< array of column widths
 
-  double             m_maxWidth;     ///< maximal allowed width
   double             m_totalWidth;   ///< total width
   double             m_totalHeight;  ///< total height
   double             m_headHeight;   ///< total height of table header

--- a/include/wex/radiochoice.h
+++ b/include/wex/radiochoice.h
@@ -77,7 +77,6 @@ private:
 	bool m_evenly;
 	wxArrayString m_captions;
 	std::vector<wxRadioButton*> m_buttons;
-	int m_selection;
 
 	DECLARE_EVENT_TABLE()
 };

--- a/include/wex/uiform.h
+++ b/include/wex/uiform.h
@@ -366,7 +366,6 @@ private:
 	int m_tabOrderCounter;
 	int m_snapSpacing;
 
-	bool m_modified;
 	wxUIObjectCopyBuffer *m_copyBuffer;
 	wxUIPropertyEditor *m_propEditor;
 	std::vector<wxUIObject*> m_selected;

--- a/src/pdf/pdfcffdecoder.cpp
+++ b/src/pdf/pdfcffdecoder.cpp
@@ -63,10 +63,6 @@ enum {
   XUID_OP         = 0x000e
 };
 
-const int NUM_STD_STRINGS = 391;
-
-const char SUBR_RETURN_OP = 11;
-
 #if 0
 static const wxChar* gs_standardStrings[] = {
     // Generated from Appendix A of the CFF specification. Size should be 391.

--- a/src/pdf/pdfcffdecoder.cpp
+++ b/src/pdf/pdfcffdecoder.cpp
@@ -39,27 +39,29 @@
 // CFF Dict Operators
 // If the high byte is 0 the command is encoded with a single byte.
 
-const int BASEFONTNAME_OP = 0x0c16;
-const int CHARSET_OP      = 0x000f;
-const int CHARSTRINGS_OP  = 0x0011;
-const int CIDCOUNT_OP     = 0x0c22;
-const int COPYRIGHT_OP    = 0x0c00;
-const int ENCODING_OP     = 0x0010;
-const int FAMILYNAME_OP   = 0x0003;
-const int FDARRAY_OP      = 0x0c24;
-const int FDSELECT_OP     = 0x0c25;
-const int FONTBBOX_OP     = 0x0005;
-const int FONTNAME_OP     = 0x0c26;
-const int FULLNAME_OP     = 0x0002;
-const int LOCAL_SUB_OP    = 0x0013;
-const int NOTICE_OP       = 0x0001;
-const int POSTSCRIPT_OP   = 0x0c15;
-const int PRIVATE_OP      = 0x0012;
-const int ROS_OP          = 0x0c1e;
-const int UNIQUEID_OP     = 0x000d;
-const int VERSION_OP      = 0x0000;
-const int WEIGHT_OP       = 0x0004;
-const int XUID_OP         = 0x000e;
+enum {
+  BASEFONTNAME_OP = 0x0c16,
+  CHARSET_OP      = 0x000f,
+  CHARSTRINGS_OP  = 0x0011,
+  CIDCOUNT_OP     = 0x0c22,
+  COPYRIGHT_OP    = 0x0c00,
+  ENCODING_OP     = 0x0010,
+  FAMILYNAME_OP   = 0x0003,
+  FDARRAY_OP      = 0x0c24,
+  FDSELECT_OP     = 0x0c25,
+  FONTBBOX_OP     = 0x0005,
+  FONTNAME_OP     = 0x0c26,
+  FULLNAME_OP     = 0x0002,
+  LOCAL_SUB_OP    = 0x0013,
+  NOTICE_OP       = 0x0001,
+  POSTSCRIPT_OP   = 0x0c15,
+  PRIVATE_OP      = 0x0012,
+  ROS_OP          = 0x0c1e,
+  UNIQUEID_OP     = 0x000d,
+  VERSION_OP      = 0x0000,
+  WEIGHT_OP       = 0x0004,
+  XUID_OP         = 0x000e
+};
 
 const int NUM_STD_STRINGS = 391;
 

--- a/src/pdf/pdfencrypt.cpp
+++ b/src/pdf/pdfencrypt.cpp
@@ -272,7 +272,7 @@ static void MD5Update(MD5_CTX *ctx, unsigned char const *buf, unsigned len)
  */
 static void MD5Transform(unsigned int buf[4], unsigned int const in[16])
 {
-  register unsigned int a, b, c, d;
+  unsigned int a, b, c, d;
 
   a = buf[0];
   b = buf[1];

--- a/src/pdf/pdffontsubsetcff.cpp
+++ b/src/pdf/pdffontsubsetcff.cpp
@@ -71,10 +71,6 @@ enum {
   XUID_OP         = 0x000e
 };
 
-const int NUM_STD_STRINGS = 391;
-
-const char SUBR_RETURN_OP = 11;
-
 class wxPdfCffFontObject
 {
 public:

--- a/src/pdf/pdffontsubsetcff.cpp
+++ b/src/pdf/pdffontsubsetcff.cpp
@@ -47,27 +47,29 @@ CompareInts(int n1, int n2)
 // CFF Dict Operators
 // If the high byte is 0 the command is encoded with a single byte.
 
-const int BASEFONTNAME_OP = 0x0c16;
-const int CHARSET_OP      = 0x000f;
-const int CHARSTRINGS_OP  = 0x0011;
-const int CIDCOUNT_OP     = 0x0c22;
-const int COPYRIGHT_OP    = 0x0c00;
-const int ENCODING_OP     = 0x0010;
-const int FAMILYNAME_OP   = 0x0003;
-const int FDARRAY_OP      = 0x0c24;
-const int FDSELECT_OP     = 0x0c25;
-const int FONTBBOX_OP     = 0x0005;
-const int FONTNAME_OP     = 0x0c26;
-const int FULLNAME_OP     = 0x0002;
-const int LOCAL_SUB_OP    = 0x0013;
-const int NOTICE_OP       = 0x0001;
-const int POSTSCRIPT_OP   = 0x0c15;
-const int PRIVATE_OP      = 0x0012;
-const int ROS_OP          = 0x0c1e;
-const int UNIQUEID_OP     = 0x000d;
-const int VERSION_OP      = 0x0000;
-const int WEIGHT_OP       = 0x0004;
-const int XUID_OP         = 0x000e;
+enum {
+  BASEFONTNAME_OP = 0x0c16,
+  CHARSET_OP      = 0x000f,
+  CHARSTRINGS_OP  = 0x0011,
+  CIDCOUNT_OP     = 0x0c22,
+  COPYRIGHT_OP    = 0x0c00,
+  ENCODING_OP     = 0x0010,
+  FAMILYNAME_OP   = 0x0003,
+  FDARRAY_OP      = 0x0c24,
+  FDSELECT_OP     = 0x0c25,
+  FONTBBOX_OP     = 0x0005,
+  FONTNAME_OP     = 0x0c26,
+  FULLNAME_OP     = 0x0002,
+  LOCAL_SUB_OP    = 0x0013,
+  NOTICE_OP       = 0x0001,
+  POSTSCRIPT_OP   = 0x0c15,
+  PRIVATE_OP      = 0x0012,
+  ROS_OP          = 0x0c1e,
+  UNIQUEID_OP     = 0x000d,
+  VERSION_OP      = 0x0000,
+  WEIGHT_OP       = 0x0004,
+  XUID_OP         = 0x000e
+};
 
 const int NUM_STD_STRINGS = 391;
 


### PR DESCRIPTION
This gets rid of almost all of the remaining warnings in WEX.