### PR TITLE
Silence wxpdf warnings

### DIFF
--- a/src/pdf/pdfcjkfontdata.inc
+++ b/src/pdf/pdfcjkfontdata.inc
@@ -82,6 +82,7 @@ static short cwUhc[] =
                 625, 625, 500, 583, 583, 583, 750
         };
 
+#if 0
 static short cwPGothic[] =
         {
                 305, 219, 500, 500, 500, 500, 594, 203,
@@ -129,6 +130,7 @@ static short cwPMincho[] =
                 500, 500, 367, 414, 352, 500, 477, 602,
                 469, 477, 453, 242, 219, 242, 500
         };
+#endif
 
 static const wxPdfCjkFontDesc gs_cjkFontTable[] =
         {

--- a/tools/sandbox/sandbox.cpp
+++ b/tools/sandbox/sandbox.cpp
@@ -50,8 +50,6 @@ public:
         wxInitAllImageHandlers();
         wxFrame *frm = new wxFrame(NULL, wxID_ANY, "SchedCtrl", wxDefaultPosition, wxSize(300, 200));
         frm->SetBackgroundColour(*wxWHITE);
-        wxStaticBitmap *bitmap = new wxStaticBitmap(frm, wxID_ANY, wxBITMAP_PNG_FROM_DATA(time));
-
         frm->Show();
         return true;
     }


### PR DESCRIPTION
G++ produces several warnings like this when compiling `pdffontmanager.cpp`:
```
pdfcjkfontdata.inc:117:14: warning: ‘cwPMincho’ defined but not used [-Wunused-variable]
```

Some fonts are disabled in pdfcjkfontdata.inc due to this comment:
```
        // These M$ fonts don't work cross platform.
```
These entries refer to the following static arrays in that same file: `cwPGothic`, `cwUIGothic` and `cwPMincho`. I think it would be acceptable to disable these arrays with `#if 0` guards around them to silence these warnings.

I am sending a similar patch to the upstream version of wxpdfdoc.