### PR TITLE
Remove deprecated wxWidgets method wxCodeEditControl::SetStyleBits

### DIFF
--- a/src/codeedit.cpp
+++ b/src/codeedit.cpp
@@ -303,7 +303,6 @@ void wxCodeEditCtrl::SetLanguage(Language lang) {
     // first, revert to standard style
     m_lang = NONE;
 
-    SetStyleBits(8);
     SetLayoutCache(wxSTC_CACHE_PAGE);
     SetLexer(wxSTC_LEX_NULL);
 


### PR DESCRIPTION
This patch removes a call to a deprecated wxWidgets method, `wxCodeEditControl::SetStyleBits`.  According to my reading of the wxWidgets and Scintilla manuals, we can just do away with this without any other changes.

G++ `-Wall` warns around deprecated functions and so this was warning.
