### PR TITLE
MacOS test to address SAM issue 462

### DIFF
--- a/src/codeedit.cpp
+++ b/src/codeedit.cpp
@@ -303,6 +303,7 @@ void wxCodeEditCtrl::SetLanguage(Language lang) {
     // first, revert to standard style
     m_lang = NONE;
 
+    SetStyleBits(8);
     SetLayoutCache(wxSTC_CACHE_PAGE);
     SetLexer(wxSTC_LEX_NULL);
 

--- a/src/plot/ploutdev.cpp
+++ b/src/plot/ploutdev.cpp
@@ -527,7 +527,7 @@ void wxPLGraphicsOutputDevice::TextColour(const wxColour &c) {
     m_textColour = c;
 }
 
-#define FREETYPE_TEXT 1
+//#define FREETYPE_TEXT 1
 #define FT_FONT_FACE_DEFAULT 0
 
 #include <wex/utils.h>


### PR DESCRIPTION
Re enable FREETYPE_TEXT to remove blurry graphs on MacOS - closes SAM #462