### PR TITLE
Address SAM issue 289 - ignore leap years in timeseries axis

### DIFF
--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -705,7 +705,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
         // Less than 2 days.  Need to label time.
 
         wxDateTime timeKeeper2(timeKeeper.GetTicks());
-        timeKeeper2.Add(wxTimeSpan::Minutes(60 * world_len)); // TODO 289 - check scaling
+        timeKeeper2.Add(wxTimeSpan::Minutes(60 * world_len));
         timeKeeper2.Subtract(wxTimeSpan::Minute()); //If it is 0:00 the next day, its really the same day.
         if (timeKeeper.IsDST() && !timeKeeper2.IsDST()) {
             timeKeeper.Add(wxTimeSpan::Hour());
@@ -714,7 +714,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
         if (timeKeeper.GetDay() == timeKeeper2.GetDay())
             m_timeLabel = timeKeeper.Format("%b %d");
         else if (timeKeeper.GetMonth() == timeKeeper2.GetMonth())
-            m_timeLabel = timeKeeper.Format("%b %d") + "-" + timeKeeper2.Format("%d"); // TODO fix year 2 Feb 28-01 (always been the case)
+            m_timeLabel = timeKeeper.Format("%b %d") + "-" + timeKeeper2.Format("%d");
         else
             m_timeLabel = timeKeeper.Format("%b %d") + "-" + timeKeeper2.Format("%b %d");
 

--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -676,7 +676,6 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
     // to skip leap years (SAM issue 289) - scale to first year
     int m_min_offset = m_min / 8760;
     double m_min_scaled = (double)((int)m_min % 8760); // m_min and m_max always based on 8760 (365 days with no leap years)
-    int m_max_offset = m_max / 8760;
     double m_max_scaled = (double)((int)m_max % 8760); // m_min and m_max always based on 8760 (365 days with no leap years)
     if (m_max_scaled <= m_min_scaled) m_max_scaled += 8760; // handle year end points
 
@@ -790,7 +789,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
 //            m_tickList.push_back(
 //                TickData(time + (daysVisibleInMonth * 24.0f / 2.0f), timeKeeper.Format("%b"), TickData::NONE));
             m_tickList.push_back(
-                TickData(time + (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b first"), TickData::NONE));
+                TickData(time + (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b"), TickData::NONE));
         }
 
         timeKeeper2.SetDay(wxDateTime::GetNumberOfDays(timeKeeper2.GetMonth()) / 2); //Middle of the second month.
@@ -801,7 +800,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
         //While end of month is visible.
         do {
 //            m_tickList.push_back(TickData(time, timeKeeper2.Format("%b"), TickData::NONE));
-            m_tickList.push_back(TickData(time + m_min_offset * 8760, timeKeeper2.Format("%b second"), TickData::NONE));
+            m_tickList.push_back(TickData(time + m_min_offset * 8760, timeKeeper2.Format("%b"), TickData::NONE));
             timeKeeper.Set(timeKeeper2.GetTicks()); //timeKeeper is position of last label.
             timeKeeper2.Add(wxDateSpan::Month());
             timeKeeper2.SetDay(1); //timeKeeper2 is day 1 of next month.
@@ -841,7 +840,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
         if (daysVisibleInMonth >= 7) {
             //Label the month if it has more than seven days visible.
 //            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f), timeKeeper.Format("%b"), TickData::NONE));
-            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b third"), TickData::NONE));
+            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b"), TickData::NONE));
         }
     }
 

--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -782,7 +782,7 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
 
 //        m_tickList.push_back(TickData(time + daysVisibleInMonth * 24.0f, wxEmptyString, TickData::LARGE));
         m_tickList.push_back(TickData(time + daysVisibleInMonth * 24.0f + m_min_offset * 8760, wxEmptyString, TickData::LARGE));
-        int endMonthHours = time + daysVisibleInMonth * 24.0f; //00:00 on first of next month.
+        int endMonthHours = time + m_min_offset * 8760 + daysVisibleInMonth * 24.0f; //00:00 on first of next month.
 
         if (daysVisibleInMonth >= 7) {
             //Label the month if it has more than seven days visible.
@@ -830,8 +830,8 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
 
         time += daysVisibleInMonth * 24.0f;
         timeKeeper2.Add(wxTimeSpan::Minutes(daysVisibleInMonth * 24.0f * 60.0f));
-//        while (time < m_max && timeKeeper2.GetMonth() == timeKeeper.GetMonth()) {
-        while (time < m_max_scaled && timeKeeper2.GetMonth() == timeKeeper.GetMonth()) {
+        while (time < m_max && timeKeeper2.GetMonth() == timeKeeper.GetMonth()) {
+//        while (time < m_max_scaled && timeKeeper2.GetMonth() == timeKeeper.GetMonth()) {
             daysVisibleInMonth += 1;
             timeKeeper2.Add(wxTimeSpan::Day());
             time += 24;
@@ -839,8 +839,8 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
 
         if (daysVisibleInMonth >= 7) {
             //Label the month if it has more than seven days visible.
-//            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f), timeKeeper.Format("%b"), TickData::NONE));
-            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b"), TickData::NONE));
+            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f), timeKeeper.Format("%b"), TickData::NONE));
+//            m_tickList.push_back(TickData(time - (daysVisibleInMonth * 24.0f / 2.0f) + m_min_offset * 8760, timeKeeper.Format("%b third"), TickData::NONE));
         }
     }
 

--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -668,29 +668,20 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
 
     //We need to figure out whether we are looking at hours, days, or months, and label the graph appropriately.
     wxDateTime timeKeeper(1, wxDateTime::Jan, 1971, 0, 0, 0); // works all time zones
+    wxDateTime timeKeeperRef(1, wxDateTime::Jan, 1971, 0, 0, 0); // works all time zones
 
     // leap year for min and max values
     // both are tracked as hours since Jan 1, 1971 
-    int m_min_days_to_add = 0, m_max_days_to_add = 0;
+    int m_min_days_to_add = 0;
     int m_min_num_years = m_min / 8760;
     int m_max_num_years = m_max / 8760;
 
-    wxDateTime m_min_dt = timeKeeper;
     for (size_t i = 0; i < m_min_num_years; i++) {
         //wxDateTime dt = timeKeeper.Add() later than Feb 28
 //        auto ndays = timeKeeper.GetNumberOfDays(i);
-        if (m_min_dt.IsLeapYear(i))// && m_min_dt.IsLaterThan(dt))
+        if (timeKeeperRef.IsLeapYear(i))// && m_min_dt.IsLaterThan(dt))
             m_min_days_to_add++;
 //        m_min_dt.Add(wxTimeSpan::Days(ndays+1));
-    }
-    // can start with m_min_days_to_add
-    wxDateTime m_max_dt = timeKeeper;
-    for (size_t i = 0; i < m_max_num_years; i++) {
-        //wxDateTime dt = timeKeeper.Add() later than Feb 28
-        auto ndays = timeKeeper.GetNumberOfDays(i);
-        if (m_max_dt.IsLeapYear())// && m_min_dt.IsLaterThan(dt))
-            m_max_days_to_add++;
-        m_max_dt.Add(wxTimeSpan::Days(ndays +1));
     }
 
 
@@ -730,9 +721,12 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
             timeKeeper2.Add(wxTimeSpan::Hour());
         }
 
-        if ((timeKeeper.GetMonth() == wxDateTime::Feb && timeKeeper.GetDay() == 29))
+        // TODO condition needs to be if leap year and day of year > 2/28 then add a day...
+        if ((timeKeeper.GetDayOfYear() > (31 + 27)) && (timeKeeperRef.IsLeapYear(m_min/8760)))
+//        if ((timeKeeper.GetMonth() == wxDateTime::Feb && timeKeeper.GetDay() == 29))
             timeKeeper.Add(wxTimeSpan::Hours(24));
-        if ((timeKeeper2.GetMonth() == wxDateTime::Feb && timeKeeper2.GetDay() == 29))
+//        if ((timeKeeper2.GetMonth() == wxDateTime::Feb && timeKeeper2.GetDay() == 29))
+        if ((timeKeeper2.GetDayOfYear() > (31 + 27)) && (timeKeeperRef.IsLeapYear(m_min / 8760)))
             timeKeeper2.Add(wxTimeSpan::Hours(24));
 
         //if (!(timeKeeper.GetMonth() == wxDateTime::Feb && timeKeeper.GetDay() == 29) 
@@ -781,14 +775,14 @@ void wxPLTimeAxis::RecalculateTicksAndLabel() {
         }
 
         do {
-            if (!(timeKeeper.GetMonth() == wxDateTime::Feb && timeKeeper.GetDay() == 29)) {
-                auto str = timeKeeper.Format("%b %d");
-                m_tickList.push_back(TickData(time, str, TickData::NONE));
-                time += 12;
-                if (time < m_max)
-                    m_tickList.push_back(TickData(time, wxEmptyString, TickData::LARGE)); // midnight
-                time += 12;
-            }
+            if ((timeKeeper.GetMonth() == wxDateTime::Feb && timeKeeper.GetDay() == 29)) 
+                timeKeeper.Add(wxTimeSpan::Hours(24));
+            auto str = timeKeeper.Format("%b %d");
+            m_tickList.push_back(TickData(time, str, TickData::NONE));
+            time += 12;
+            if (time < m_max)
+                m_tickList.push_back(TickData(time, wxEmptyString, TickData::LARGE)); // midnight
+            time += 12;
             timeKeeper.Add(wxTimeSpan::Hours(24));
         } while (time < m_max);
     } else {


### PR DESCRIPTION
Please test with lifetime, single year, hourly and sub-hourly files.

Please test for Feb 29 in out years as described in https://github.com/NREL/SAM/issues/289

Please test transitions between years (Dec to Jan) at various zoom levels.

Test file - detailed PV residential here 
[SAM_289.zip](https://github.com/user-attachments/files/17646381/SAM_289.zip)
