### PR TITLE
Change mask color for nan/inf values to light grey for contour plots

### DIFF
--- a/include/wex/plot/plcolourmap.h
+++ b/include/wex/plot/plcolourmap.h
@@ -41,6 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "wex/plot/plplot.h"
 
+#define wxCONTOUR_BG  wxStockGDI::GetColour(wxStockGDI::COLOUR_LIGHTGREY)
+
 class wxPLColourMap : public wxPLSideWidgetBase {
 public:
     wxPLColourMap(double min = 0, double max = 1);

--- a/src/plot/plcolourmap.cpp
+++ b/src/plot/plcolourmap.cpp
@@ -159,7 +159,7 @@ void wxPLColourMap::Render(wxPLOutputDevice &dc, const wxPLRealRect &geom) {
 }
 
 wxColour wxPLColourMap::ColourForValue(double val) {
-    if (m_colourList.size() == 0 || !(wxFinite(val))) return *wxBLACK;
+    if (m_colourList.size() == 0 || !(wxFinite(val))) return *wxCONTOUR_BG;
 
     int position =
             (int) (((double) m_colourList.size()) * (

--- a/src/plot/plcontourplot.cpp
+++ b/src/plot/plcontourplot.cpp
@@ -143,9 +143,20 @@ void wxPLContourPlot::RebuildContours() {
             }
         }
     } else {
-        for (size_t k = 0; k < m_levels.size() - 1; k++) {
-            double zlow = m_levels[k];
-            double zhigh = m_levels[k + 1];
+        for (size_t k = 0; k < m_levels.size(); k++) {
+            double zlow = 0;
+            double zhigh = 0;
+            if (k == 0) {
+                zlow = m_levels[k] - (m_levels[1] - m_levels[0]);
+                zhigh = m_levels[k];
+            }
+            else {
+                zlow = m_levels[k-1];
+                zhigh = m_levels[k];
+            }
+
+            //double zlow = m_levels[k];
+            //double zhigh = m_levels[k + 1];
 
             std::vector<QuadContourGenerator::VertexCodes *> list;
             qcg.create_filled_contour(zlow, zhigh, list);
@@ -250,16 +261,17 @@ void wxPLContourPlot::Draw(wxPLOutputDevice &dc, const wxPLDeviceMapping &map) {
         dc.NoPen();
         // background set to min
         // assume RebuildMask has been called
-        wxColor bgc(m_cmap->ColourForValue(m_zMin));
+        //wxColor bgc(m_cmap->ColourForValue(m_zMin));
+        wxColor bgc(*wxLIGHT_GREY);
         dc.Brush(bgc);
         wxRealPoint pos, size;
         map.GetDeviceExtents(&pos, &size);
         dc.Rect(pos.x, pos.y, size.x, size.y);
         // end background
-
 //		int ipoly = 0;
         for (size_t i = 0; i < m_cPolys.size(); i++) {
             double zmid = 0.5 * (m_cPolys[i].z + m_cPolys[i].zmax);
+            //double zmid = m_cPolys[i].z;
             wxColour color(m_cmap->ColourForValue(zmid));
             dc.Pen(color, 2);
             dc.Brush(color);

--- a/src/plot/plcontourplot.cpp
+++ b/src/plot/plcontourplot.cpp
@@ -262,7 +262,7 @@ void wxPLContourPlot::Draw(wxPLOutputDevice &dc, const wxPLDeviceMapping &map) {
         // background set to min
         // assume RebuildMask has been called
         //wxColor bgc(m_cmap->ColourForValue(m_zMin));
-        wxColor bgc(*wxLIGHT_GREY);
+        wxColor bgc(*wxCONTOUR_BG);
         dc.Brush(bgc);
         wxRealPoint pos, size;
         map.GetDeviceExtents(&pos, &size);


### PR DESCRIPTION
-Rather than drawing nonfinite results as the minimum color in contour plots, draw them as light grey
-Start from the minimum value for contour layer plotting rather than min value + 1; previously, contour made min color the background then counted from the next layer
-Light grey preset is now background color before any layers are drawn
-Useful in parametrics with Nan or inf values in outputs, such as payback period or internal rate of return
