### PR TITLE
Fix wxDVDMapPlot dithering issue for sub-hourly timesteps

### DIFF
--- a/src/dview/dvdmapctrl.cpp
+++ b/src/dview/dvdmapctrl.cpp
@@ -125,8 +125,7 @@ public:
             int worldXDay = int(m_data->At(i).x) / 24; //x-res does not change with higher res data.
 
             double worldY = fmod(m_data->At(i).x, 24.0);
-            worldY -= fmod(worldY,
-                           m_data->GetTimeStep()); // This makes sure the entire plot doesn't shift up for something like 1/2 hour data.
+            worldY -= fmod(worldY, m_data->GetTimeStep()); // This makes sure the entire plot doesn't shift up for something like 1/2 hour data.
             if (worldY < wmin.y)
                 continue;
             if (worldY >= wmax.y)
@@ -134,15 +133,15 @@ public:
             worldY -= wmin.y;
 
             double x = pos.x + (worldXDay - wmin.x / 24) * dRectWidth;
-            double y = pos.y + size.y - dRectHeight * (worldY / m_data->GetTimeStep() +
-                                                       1); //+1 is because we have top corner, not bottom.
+            double y = pos.y + size.y - dRectHeight * (worldY / m_data->GetTimeStep() + 1); //+1 is because we have top corner, not bottom.
 
             dc.Brush(m_colourMap->ColourForValue(m_data->At(i).y));
 
             // increase rect dimensions by about 0.5 point to
             // make sure they render overlapped without white space
             // showing in between
-            dc.Rect(x, y, ceil(dRectWidth + 0.5), ceil(dRectHeight + 0.5)); //+1s cover empty spaces between rects.
+//            dc.Rect(x, y, ceil(dRectWidth + 0.5), ceil(dRectHeight + 0.5)); //+1s cover empty spaces between rects.
+            dc.Rect(x, y, ceil(dRectWidth + 0.5 / m_data->GetTimeStep()), ceil(dRectHeight + 0.5 / m_data->GetTimeStep())); //+1s cover empty spaces between rects.
         }
     }
 

--- a/src/dview/dvdmapctrl.cpp
+++ b/src/dview/dvdmapctrl.cpp
@@ -100,8 +100,9 @@ public:
 
         dc.Pen(*wxWHITE, 0, wxPLOutputDevice::NONE);
         dc.Brush(*wxRED, wxPLOutputDevice::HATCH);
+        dc.Brush(m_colourMap->ColourForValue(m_data->At(0).y));
         dc.Rect(pos.x, pos.y, size.x + 1, size.y + 1);
-
+        
         wxRealPoint wmin = map.GetWorldMinimum();
         wxRealPoint wmax = map.GetWorldMaximum();
         double xlen = wmax.x - wmin.x;
@@ -140,8 +141,7 @@ public:
             // increase rect dimensions by about 0.5 point to
             // make sure they render overlapped without white space
             // showing in between
-//            dc.Rect(x, y, ceil(dRectWidth + 0.5), ceil(dRectHeight + 0.5)); //+1s cover empty spaces between rects.
-            dc.Rect(x, y, ceil(dRectWidth + 0.5 / m_data->GetTimeStep()), ceil(dRectHeight + 0.5 / m_data->GetTimeStep())); //+1s cover empty spaces between rects.
+            dc.Rect(x, y, ceil(dRectWidth + 1.0 / m_data->GetTimeStep()), ceil(dRectHeight + 1.0 / m_data->GetTimeStep())); // +- 1/timesteps to cover empty spaces between rects.
         }
     }
 


### PR DESCRIPTION
Refers to  per https://github.com/NREL/SAM/issues/1616

To test use weather files and project files here 
[SAM_1616.zip](https://github.com/user-attachments/files/19602029/SAM_1616.zip)

Test in 2024.12.12 release and check "Heat map" for sub hourly simulations, e.g. 5min weather file
![image](https://github.com/user-attachments/assets/beee6b30-2f23-4300-bce0-68fb61b8cebd)

Build with SAM_1616 branch of wex and develop branches of other repos and expect to see
![image](https://github.com/user-attachments/assets/62e1546f-c5a7-4e21-9f38-838c8a0baefd)

