### PR TITLE
matrix.h had unknown function nrows() and ncols() that should not have compiled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  WX_VERSION: '3.2.4'
+  WX_VERSION: '3.2.8'
   DEFAULT_BRANCH: develop
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  WX_VERSION: '3.2.8'
+  WX_VERSION: '3.2.8.1'
   DEFAULT_BRANCH: develop
 
 

--- a/include/wex/matrix.h
+++ b/include/wex/matrix.h
@@ -175,8 +175,8 @@ public:
         wxMatrix<T> old(*this);
         Resize(nr, nc);
         Fill(val);
-        for (size_t r = 0; r < nr && r < old.nrows(); r++)
-            for (size_t c = 0; c < nc && c < old.ncols(); c++)
+        for (size_t r = 0; r < nr && r < old.Rows(); r++)
+            for (size_t c = 0; c < nc && c < old.Cols(); c++)
                 At(r, c) = old(r, c);
     }
 


### PR DESCRIPTION
matrix.h would not compile on XCode 16.4 and should not have built on other platforms. wxMatrix::ResizePreserve had undefined methods nrows() and ncols() used. Luckily the ResizePreserve function was not used elsewhere in the code base.