### PR TITLE
Fix macOS build, file dialog, and dark mode UI

### DIFF
--- a/include/wex/matrix.h
+++ b/include/wex/matrix.h
@@ -175,8 +175,8 @@ public:
         wxMatrix<T> old(*this);
         Resize(nr, nc);
         Fill(val);
-        for (size_t r = 0; r < nr && r < old.nrows(); r++)
-            for (size_t c = 0; c < nc && c < old.ncols(); c++)
+        for (size_t r = 0; r < nr && r < old.Rows(); r++)
+            for (size_t c = 0; c < nc && c < old.Cols(); c++)
                 At(r, c) = old(r, c);
     }
 

--- a/src/dview/dvdcctrl.cpp
+++ b/src/dview/dvdcctrl.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wx/app.h>
 #include <wx/busyinfo.h>
 #include <wx/config.h>
+#include <wx/settings.h>
 #include <wx/tokenzr.h>
 
 #include "wx/srchctrl.h"
@@ -56,16 +57,24 @@ enum {
 wxDVDCCtrl::wxDVDCCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos,
                        const wxSize &size, long style, const wxString &name)
         : wxPanel(parent, id, pos, size, style, name) {
+    wxColour bgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColour fgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    SetBackgroundColour(bgColour);
+    SetForegroundColour(fgColour);
+
     wxBoxSizer *topSizer = new wxBoxSizer(wxHORIZONTAL);
     SetSizer(topSizer);
     m_srchCtrl = NULL;
     m_plotSurface = new wxPLPlotCtrl(this, wxID_ANY);
     m_plotSurface->SetBackgroundColour(*wxWHITE);
+    m_plotSurface->SetForegroundColour(*wxBLACK);
     m_plotSurface->ShowTitle(false);
     m_plotSurface->ShowLegend(false);
     topSizer->Add(m_plotSurface, 1, wxEXPAND | wxALL, 10);
 
     m_srchCtrl = new wxSearchCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(150, -1), 0);
+    m_srchCtrl->SetBackgroundColour(bgColour);
+    m_srchCtrl->SetForegroundColour(fgColour);
     m_dataSelector = new wxDVSelectionListCtrl(this, wxID_DC_DATA_SELECTOR, 1);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(m_srchCtrl, 0, wxALL | wxEXPAND, 0);

--- a/src/dview/dvdmapctrl.cpp
+++ b/src/dview/dvdmapctrl.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wx/choice.h>
 #include <wx/config.h>
 #include <wx/scrolbar.h>
+#include <wx/settings.h>
 #include "wx/srchctrl.h"
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
@@ -210,12 +211,18 @@ wxDVDMapCtrl::wxDVDMapCtrl(wxWindow *parent,
           m_timer(nullptr),
           m_xAxixWorldMin(0),
           m_xAxixWorldMax(0) {
+    wxColour bgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColour fgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    SetBackgroundColour(bgColour);
+    SetForegroundColour(fgColour);
+
     m_currentlyShownDataSet = 0;
     m_srchCtrl = NULL;
     m_colourMap = new wxPLJetColourMap(0, 24);
 
     m_plotSurface = new wxPLPlotCtrl(this, ID_DMAP_SURFACE);
     m_plotSurface->SetBackgroundColour(*wxWHITE);
+    m_plotSurface->SetForegroundColour(*wxBLACK);
     m_plotSurface->SetHighlightMode(wxPLPlotCtrl::HIGHLIGHT_SPAN);
     m_plotSurface->ShowGrid(false, false);
     m_plotSurface->ShowTitle(false);
@@ -235,15 +242,23 @@ wxDVDMapCtrl::wxDVDMapCtrl(wxWindow *parent,
 
     m_minTextBox = new wxTextCtrl(this, ID_MIN_Z_INPUT, wxEmptyString, wxDefaultPosition, wxDefaultSize,
                                   wxTE_PROCESS_ENTER);
+    m_minTextBox->SetBackgroundColour(bgColour);
+    m_minTextBox->SetForegroundColour(fgColour);
     m_maxTextBox = new wxTextCtrl(this, ID_MAX_Z_INPUT, wxEmptyString, wxDefaultPosition, wxDefaultSize,
                                   wxTE_PROCESS_ENTER);
+    m_maxTextBox->SetBackgroundColour(bgColour);
+    m_maxTextBox->SetForegroundColour(fgColour);
 
     wxString choices[5] = {"Jet", "Parula", "Grayscale", "Coarse Rainbow", "Fine Rainbow"};
     m_colourMapSelector = new wxChoice(this, ID_COLOURMAP_SELECTOR_CHOICE, wxDefaultPosition, wxDefaultSize, 5,
                                        choices);
     m_colourMapSelector->SetSelection(0);
+    m_colourMapSelector->SetBackgroundColour(bgColour);
+    m_colourMapSelector->SetForegroundColour(fgColour);
 
     m_reverseColours = new wxCheckBox(this, ID_REVERSE_COLOURS, "Reverse colors");
+    m_reverseColours->SetBackgroundColour(bgColour);
+    m_reverseColours->SetForegroundColour(fgColour);
 
     m_yGraphScroller = new wxScrollBar(this, ID_GRAPH_Y_SCROLLBAR, wxDefaultPosition, wxDefaultSize, wxSB_VERTICAL);
     m_xGraphScroller = new wxScrollBar(this, ID_GRAPH_SCROLLBAR, wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL);
@@ -264,6 +279,8 @@ wxDVDMapCtrl::wxDVDMapCtrl(wxWindow *parent,
     scrollSizer->Add(zoom_fit, 0, wxALL | wxEXPAND, 1);
 
     m_srchCtrl = new wxSearchCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(150, -1), 0);
+    m_srchCtrl->SetBackgroundColour(bgColour);
+    m_srchCtrl->SetForegroundColour(fgColour);
     m_selector = new wxDVSelectionListCtrl(this, ID_DATA_SELECTOR, 1, wxDefaultPosition, wxDefaultSize,
                                            wxDVSEL_RADIO_FIRST_COL | wxDVSEL_NO_COLOURS);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
@@ -280,13 +297,19 @@ wxDVDMapCtrl::wxDVDMapCtrl(wxWindow *parent,
     optionsSizer->Add(m_colourMapSelector, 0, wxALL | wxEXPAND, 3);
     optionsSizer->Add(m_reverseColours, 0, wxLEFT | wxRIGHT | wxALIGN_CENTER_VERTICAL, 5);
     optionsSizer->AddStretchSpacer();
-    optionsSizer->Add(new wxStaticText(this, wxID_ANY, "Min:"), 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 4);
+    wxStaticText* minLabel = new wxStaticText(this, wxID_ANY, "Min:");
+    minLabel->SetForegroundColour(fgColour);
+    optionsSizer->Add(minLabel, 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 4);
     optionsSizer->Add(m_minTextBox, 0, wxALL | wxALIGN_CENTER_VERTICAL, 3);
     optionsSizer->AddSpacer(6);
-    optionsSizer->Add(new wxStaticText(this, wxID_ANY, "Max:"), 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 4);
+    wxStaticText* maxLabel = new wxStaticText(this, wxID_ANY, "Max:");
+    maxLabel->SetForegroundColour(fgColour);
+    optionsSizer->Add(maxLabel, 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 4);
     optionsSizer->Add(m_maxTextBox, 0, wxALL | wxALIGN_CENTER_VERTICAL, 3);
-    optionsSizer->Add(new wxButton(this, ID_RESET_MIN_MAX, "Reset", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT), 0,
-                      wxALIGN_CENTER | wxRIGHT, 5);
+    wxButton* resetBtn = new wxButton(this, ID_RESET_MIN_MAX, "Reset", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+    resetBtn->SetBackgroundColour(bgColour);
+    resetBtn->SetForegroundColour(fgColour);
+    optionsSizer->Add(resetBtn, 0, wxALIGN_CENTER | wxRIGHT, 5);
 
     wxBoxSizer *leftSizer = new wxBoxSizer(wxVERTICAL);
     leftSizer->Add(optionsSizer, 0, wxEXPAND, 2);

--- a/src/dview/dvpncdfctrl.cpp
+++ b/src/dview/dvpncdfctrl.cpp
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <wx/wx.h>
 #include <wx/busyinfo.h>
+#include <wx/settings.h>
 #include "wx/srchctrl.h"
 #include <wx/tokenzr.h>
 #include <wx/config.h>
@@ -75,11 +76,17 @@ END_EVENT_TABLE()
 wxDVPnCdfCtrl::wxDVPnCdfCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos,
                              const wxSize &size, long style, const wxString &name, const bool &bshowsearch, const bool &bshowselector, const bool& bshowpvalue, const bool& bshowhidezeros)
         : wxPanel(parent, id, pos, size, style, name) {
+    wxColour bgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColour fgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    SetBackgroundColour(bgColour);
+    SetForegroundColour(fgColour);
+
     m_bshowpvalue = bshowpvalue;
     m_bshowhidezeros = bshowhidezeros;
     m_srchCtrl = NULL;
     m_plotSurface = new wxPLPlotCtrl(this, wxID_ANY);
     m_plotSurface->SetBackgroundColour(*wxWHITE);
+    m_plotSurface->SetForegroundColour(*wxBLACK);
     m_pdfPlot = new wxPLHistogramPlot();
     m_cdfPlot = new wxPLLinePlot();
     m_cdfPlot->SetColour(*wxBLACK);
@@ -94,12 +101,16 @@ wxDVPnCdfCtrl::wxDVPnCdfCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos
     if (m_bshowpvalue) m_pValueTextBox = new wxTextCtrl(this, wxID_PVALUE_TB, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     
     m_pValueResultLabel = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
+    m_pValueResultLabel->SetForegroundColour(fgColour);
     m_pValueResultTextBox = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT | wxTE_READONLY);
-    m_pValueResultTextBox->SetForegroundColour(UIColorCalculatedFore);
-    m_pValueResultTextBox->SetBackgroundColour(UIColorCalculatedBack);
+    m_pValueResultTextBox->SetForegroundColour(fgColour);
+    m_pValueResultTextBox->SetBackgroundColour(bgColour);
     m_pValueResultUnits = new wxStaticText(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT);
+    m_pValueResultUnits->SetForegroundColour(fgColour);
 
     m_srchCtrl = new wxSearchCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(150, -1), 0);
+    m_srchCtrl->SetBackgroundColour(bgColour);
+    m_srchCtrl->SetForegroundColour(fgColour);
     m_selector = new wxDVSelectionListCtrl(this, ID_DATA_SELECTOR, 1, wxDefaultPosition, wxDefaultSize,
                                            wxDVSEL_RADIO_FIRST_COL | wxDVSEL_NO_COLOURS);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
@@ -111,7 +122,11 @@ wxDVPnCdfCtrl::wxDVPnCdfCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos
     if (!bshowselector)
         m_selector->Hide();
 
-    if (m_bshowhidezeros) m_hideZeros = new wxCheckBox(this, wxID_ANY, "Exclude Zero Values", wxDefaultPosition, wxDefaultSize,  wxALIGN_RIGHT);
+    if (m_bshowhidezeros) {
+        m_hideZeros = new wxCheckBox(this, wxID_ANY, "Exclude Zero Values", wxDefaultPosition, wxDefaultSize,  wxALIGN_RIGHT);
+        m_hideZeros->SetBackgroundColour(bgColour);
+        m_hideZeros->SetForegroundColour(fgColour);
+    }
     /*
     m_PlotTypeDisplayed = new wxChoice(this, wxID_PLOT_TYPE);
     m_PlotTypeDisplayed->Append(wxT("PDF and CDF"));

--- a/src/dview/dvprofilectrl.cpp
+++ b/src/dview/dvprofilectrl.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wx/config.h>
 #include <wx/dcbuffer.h>
 #include <wx/fileconf.h>
+#include <wx/settings.h>
 #include <wx/sizer.h>
 #include "wx/srchctrl.h"
 #include <wx/tokenzr.h>
@@ -133,7 +134,6 @@ public:
     VerticalLabelCtrl(wxWindow *parent, wxWindowID id)
             : wxWindow(parent, id) {
         SetBackgroundStyle(wxBG_STYLE_CUSTOM);
-        SetBackgroundColour(*wxWHITE);
     }
 
     virtual wxSize DoGetBestSize() const {
@@ -206,6 +206,10 @@ wxDVProfileCtrl::wxDVProfileCtrl(wxWindow *parent, wxWindowID id, const wxPoint 
     m_srchCtrl = NULL;
     wxScrolledWindow *monthSelector = new wxScrolledWindow(this, wxID_ANY,
                                                            wxDefaultPosition, wxDefaultSize, wxHSCROLL);
+    wxColour bgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColour fgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    monthSelector->SetBackgroundColour(bgColour);
+    monthSelector->SetForegroundColour(fgColour);
     wxBoxSizer *monthSizer = new wxBoxSizer(wxHORIZONTAL);
     monthSelector->SetSizer(monthSizer);
     monthSelector->SetScrollRate(10, 0);
@@ -213,14 +217,20 @@ wxDVProfileCtrl::wxDVProfileCtrl(wxWindow *parent, wxWindowID id, const wxPoint 
         m_monthCheckBoxes[i] = new wxCheckBox(monthSelector, ID_JAN_CHECK + i,
                                               wxDateTime::GetMonthName(wxDateTime::Month(i), wxDateTime::Name_Abbr));
         m_monthCheckBoxes[i]->SetValue(true);
+        m_monthCheckBoxes[i]->SetBackgroundColour(bgColour);
+        m_monthCheckBoxes[i]->SetForegroundColour(fgColour);
         monthSizer->Add(m_monthCheckBoxes[i], 0, wxALL, 5);
     }
     m_numberOfPlotSurfacesShown = 12;
     //Add an extra at the end for the annual profile.
     m_monthCheckBoxes[12] = new wxCheckBox(monthSelector, ID_ANNUAL_CHECK, wxT("Annual"));
+    m_monthCheckBoxes[12]->SetBackgroundColour(bgColour);
+    m_monthCheckBoxes[12]->SetForegroundColour(fgColour);
     monthSizer->Add(m_monthCheckBoxes[12], 0, wxALL, 5);
-    monthSizer->Add(new wxCheckBox(monthSelector, ID_SEL_ALL_CHECK,
-                                   wxT("Select All")), 0, wxALL, 5);
+    wxCheckBox* selAllCheck = new wxCheckBox(monthSelector, ID_SEL_ALL_CHECK, wxT("Select All"));
+    selAllCheck->SetBackgroundColour(bgColour);
+    selAllCheck->SetForegroundColour(fgColour);
+    monthSizer->Add(selAllCheck, 0, wxALL, 5);
     for (int i = 0; i < 12; i++) {
         m_plotSurfaces[i] = new wxPLPlotCtrl(this, wxID_ANY);
         m_plotSurfaces[i]->SetIncludeLegendOnExport(true);
@@ -231,6 +241,7 @@ wxDVProfileCtrl::wxDVProfileCtrl(wxWindow *parent, wxWindowID id, const wxPoint 
     }
     //Add annual profile:
     m_plotSurfaces[12] = new wxPLPlotCtrl(this, wxID_ANY);
+    m_plotSurfaces[12]->SetBackgroundColour(*wxWHITE);
     m_plotSurfaces[12]->SetTitle(wxT("Annual Profile"));
     m_plotSurfaces[12]->ShowGrid(true, false);
     m_plotSurfaces[12]->ShowLegend(false);

--- a/src/dview/dvscatterplotctrl.cpp
+++ b/src/dview/dvscatterplotctrl.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <wx/wx.h>
 #include <wx/config.h>
+#include <wx/settings.h>
 #include "wx/srchctrl.h"
 #include <wx/tokenzr.h>
 
@@ -93,14 +94,22 @@ END_EVENT_TABLE()
 wxDVScatterPlotCtrl::wxDVScatterPlotCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos,
                                          const wxSize &size, long style, const wxString &name)
         : wxPanel(parent, id, pos, size, style, name) {
+    wxColour bgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+    wxColour fgColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    SetBackgroundColour(bgColour);
+    SetForegroundColour(fgColour);
+
     m_srchCtrl = NULL;
 
     m_plotSurface = new wxPLPlotCtrl(this, wxID_ANY);
     m_plotSurface->ShowTitle(false);
     m_plotSurface->SetBackgroundColour(*wxWHITE);
+    m_plotSurface->SetForegroundColour(*wxBLACK);
     m_plotSurface->ShowLegend(false);
 
     m_srchCtrl = new wxSearchCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxSize(150, -1), 0);
+    m_srchCtrl->SetBackgroundColour(bgColour);
+    m_srchCtrl->SetForegroundColour(fgColour);
     m_dataSelectionList = new wxDVSelectionListCtrl(this, wxID_SCATTER_DATA_SELECTOR, 2, wxDefaultPosition,
                                                     wxDefaultSize, wxDVSEL_RADIO_FIRST_COL);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
@@ -113,6 +122,8 @@ wxDVScatterPlotCtrl::wxDVScatterPlotCtrl(wxWindow *parent, wxWindowID id, const 
     wxBoxSizer *optionsSizer = new wxBoxSizer(wxHORIZONTAL);
     m_showPerfAgreeLine = new wxCheckBox(this, wxID_PERFECT_AGREE_LINE, "Show Line of Perfect Agreement",
                                          wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT);
+    m_showPerfAgreeLine->SetBackgroundColour(bgColour);
+    m_showPerfAgreeLine->SetForegroundColour(fgColour);
     optionsSizer->Add(m_showPerfAgreeLine, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
     wxBoxSizer *topSizer = new wxBoxSizer(wxHORIZONTAL);

--- a/src/dview/dvselectionlist.cpp
+++ b/src/dview/dvselectionlist.cpp
@@ -451,6 +451,13 @@ void wxDVSelectionListCtrl::OnPaint(wxPaintEvent &) {
 
     // paint the background.
     wxColour bg = GetBackgroundColour();
+    
+    // Determine text color based on background luminance
+    // Standard relative luminance formula
+    double luminance = (0.299 * bg.Red() + 0.587 * bg.Green() + 0.114 * bg.Blue()) / 255.0;
+    wxColour fg = (luminance < 0.5) ? *wxWHITE : *wxBLACK;
+    wxColour dis_fg = (luminance < 0.5) ? wxColour(150, 150, 150) : *wxLIGHT_GREY;
+    
     dc.SetBrush(wxBrush(bg));
     dc.SetPen(wxPen(bg, 1));
     wxRect windowRect(wxPoint(0, 0), GetClientSize());
@@ -507,10 +514,10 @@ void wxDVSelectionListCtrl::OnPaint(wxPaintEvent &) {
             }
 
             for (size_t c = 0; c < (size_t) m_numCols; c++) {
-                wxColour color = items[i]->enable[c] ? *wxBLACK : *wxLIGHT_GREY;
+                wxColour color = items[i]->enable[c] ? fg : dis_fg;
                 items[i]->geom[c] = wxRect(x, y + yoff, m_boxSize, m_boxSize); // save geometry to speed up mouse clicks
 
-                dc.SetBrush(*wxWHITE_BRUSH);
+                dc.SetBrush(wxBrush(bg));
                 dc.SetPen(wxPen(color, 1));
 
                 if (((m_style & wxDVSEL_RADIO_FIRST_COL) && c == 0) || (m_style == wxDVSEL_RADIO_ALL_COL))
@@ -519,8 +526,8 @@ void wxDVSelectionListCtrl::OnPaint(wxPaintEvent &) {
                     dc.DrawRectangle(x, y + yoff, m_boxSize, m_boxSize);
 
                 if (items[i]->value[c]) {
-                    dc.SetBrush(*wxBLACK_BRUSH);
-                    dc.SetPen(*wxBLACK_PEN);
+                    dc.SetBrush(wxBrush(fg));
+                    dc.SetPen(wxPen(fg));
                     if (((m_style & wxDVSEL_RADIO_FIRST_COL) && c == 0) || (m_style == wxDVSEL_RADIO_ALL_COL))
                         dc.DrawCircle(x + radius, y + radius + yoff, radius - 2);
                     else
@@ -531,7 +538,7 @@ void wxDVSelectionListCtrl::OnPaint(wxPaintEvent &) {
             }
 
             dc.SetFont(font_normal);
-            dc.SetTextForeground(*wxBLACK);
+            dc.SetTextForeground(fg);
             dc.DrawText(items[i]->label, x + 2, y + m_itemHeight / 2 - dc.GetCharHeight() / 2 - 1);
 
             y += m_itemHeight;

--- a/src/dview/dvselectionlist.cpp
+++ b/src/dview/dvselectionlist.cpp
@@ -457,6 +457,7 @@ void wxDVSelectionListCtrl::OnPaint(wxPaintEvent &) {
     double luminance = (0.299 * bg.Red() + 0.587 * bg.Green() + 0.114 * bg.Blue()) / 255.0;
     wxColour fg = (luminance < 0.5) ? *wxWHITE : *wxBLACK;
     wxColour dis_fg = (luminance < 0.5) ? wxColour(150, 150, 150) : *wxLIGHT_GREY;
+    fprintf(stderr, "DView: bg=(%d, %d, %d) luminance=%f fg=(%d, %d, %d)\n", bg.Red(), bg.Green(), bg.Blue(), luminance, fg.Red(), fg.Green(), fg.Blue()); fflush(stderr);
     
     dc.SetBrush(wxBrush(bg));
     dc.SetPen(wxPen(bg, 1));

--- a/src/dview/dvtimeseriesctrl.cpp
+++ b/src/dview/dvtimeseriesctrl.cpp
@@ -784,6 +784,7 @@ wxDVTimeSeriesCtrl::wxDVTimeSeriesCtrl(wxWindow *parent, wxWindowID id, wxDVTime
           m_xAxixWorldMin(0),
           m_xAxixWorldMax(0) {
     SetBackgroundColour(*wxWHITE);
+    SetForegroundColour(*wxBLACK);
     m_srchCtrl = NULL;
     m_stackingOnYLeft = false;
     m_topAutoScale = false;
@@ -797,6 +798,7 @@ wxDVTimeSeriesCtrl::wxDVTimeSeriesCtrl(wxWindow *parent, wxWindowID id, wxDVTime
 
     m_plotSurface = new wxPLPlotCtrl(this, ID_PLOT_SURFACE);
     m_plotSurface->SetBackgroundColour(*wxWHITE);
+    m_plotSurface->SetForegroundColour(*wxBLACK);
     m_plotSurface->SetHighlightMode(wxPLPlotCtrl::HIGHLIGHT_SPAN);
     m_plotSurface->ShowTitle(false);
     m_plotSurface->ShowLegend(false);

--- a/src/metro.cpp
+++ b/src/metro.cpp
@@ -44,6 +44,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "wex/metro.h"
 #include "wex/utils.h"
 
+static wxColour GetContrastingTextColour(const wxColour& bg) {
+    double luminance = (0.299 * bg.Red() + 0.587 * bg.Green() + 0.114 * bg.Blue()) / 255.0;
+    return (luminance < 0.5) ? *wxWHITE : *wxBLACK;
+}
+
 #include "wex/icons/up_arrow_13.cpng"
 #include "wex/icons/down_arrow_13.cpng"
 #include "wex/icons/left_arrow_13.cpng"
@@ -635,13 +640,18 @@ void wxMetroTabList::OnPaint(wxPaintEvent &) {
             }
         }
 
-        wxColour text(*wxWHITE);
+        wxColour text;
         if (light) {
+            wxColour bg = *wxWHITE;
             text = ((int) i == m_selection
                     ? wxMetroTheme::Colour(wxMT_FOREGROUND)
                     : ((int) i == m_hoverIdx
                        ? wxMetroTheme::Colour(wxMT_SELECT)
                        : wxMetroTheme::Colour(wxMT_TEXT)));
+            text = GetContrastingTextColour(bg);
+        } else {
+            wxColour bg = wxMetroTheme::Colour(wxMT_FOREGROUND);
+            text = GetContrastingTextColour(bg);
         }
 
         dc.SetTextForeground(text);
@@ -1342,7 +1352,7 @@ void wxMetroListBox::OnPaint(wxPaintEvent &) {
                            &windowRect.x, &windowRect.y);
     dc.DrawRectangle(windowRect);
     dc.SetFont(GetFont());
-    dc.SetTextForeground(*wxBLACK);
+    dc.SetTextForeground(GetContrastingTextColour(bg));
     int height = dc.GetCharHeight();
     for (size_t i = 0; i < m_items.size(); i++) {
         wxColour bcol = (m_selectedIdx == (int) i) ? wxColour(50, 50, 50) :
@@ -1350,7 +1360,7 @@ void wxMetroListBox::OnPaint(wxPaintEvent &) {
         dc.SetPen(wxPen(bcol));
         dc.SetBrush(wxBrush(bcol));
         dc.DrawRectangle(m_items[i].geom);
-        dc.SetTextForeground((m_selectedIdx == (int) i) ? *wxWHITE : *wxBLACK);
+        dc.SetTextForeground(GetContrastingTextColour(bcol));
         dc.DrawText(m_items[i].name, m_space / 2, m_items[i].geom.y + m_items[i].geom.height / 2 - height / 2);
     }
 }

--- a/src/pdf/pdfdc.cpp
+++ b/src/pdf/pdfdc.cpp
@@ -593,7 +593,7 @@ wxPdfDCImpl::DoDrawSpline(const wxPointList *points) {
     m_pdfDocument->CurveTo(bx1, by1, bx2, by2, bx3, by3);
 
 #if !wxUSE_STL
-    while ((node = node->GetNext()) != NULL)
+    while ((node = node->GetNext()) != nullptr)
 #else
     while ((node = node->GetNext()))
 #endif // !wxUSE_STL

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,6 +39,7 @@ if (APPLE)
     set(DVIEW_ICON ${CMAKE_CURRENT_SOURCE_DIR}/../build_resources/DView.icns)
     set_source_files_properties(${DVIEW_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
     set(APPS "\${CMAKE_INSTALL_PREFIX}/DView.app")
+    set(MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in)
 elseif (WIN32)
     set(DVIEW_ICON ${CMAKE_CURRENT_SOURCE_DIR}/../build_resources/dview.rc)
     set(APPS "\${CMAKE_INSTALL_PREFIX}/DView.exe")
@@ -49,6 +50,19 @@ add_executable(DView
         MACOSX_BUNDLE
         ${DVIEW_SRC}
         ${DVIEW_ICON})
+
+if (APPLE)
+    set_target_properties(DView PROPERTIES
+            MACOSX_BUNDLE_INFO_PLIST ${MACOSX_BUNDLE_INFO_PLIST}
+            XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/DView.entitlements"
+    )
+    
+    # Custom post-build command to bundle dylibs and sign the app properly with entitlements
+    add_custom_command(TARGET DView POST_BUILD
+        COMMAND dylibbundler -od -b -x $<TARGET_FILE_DIR:DView>/DView -d $<TARGET_FILE_DIR:DView>/../Frameworks -p @executable_path/../Frameworks/
+        COMMAND codesign --force --deep --sign - --entitlements ${CMAKE_CURRENT_SOURCE_DIR}/DView.entitlements $<TARGET_FILE_DIR:DView>/../..
+    )
+endif()
 
 target_include_directories(DView SYSTEM PRIVATE ../include ../src/freetype/include ${LKDIR}/include ${CURL_DIR}/include)
 

--- a/tools/DView.entitlements
+++ b/tools/DView.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/tools/Info.plist.in
+++ b/tools/Info.plist.in
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>DView</string>
+	<key>CFBundleIconFile</key>
+	<string>DView.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>gov.nrel.dview</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>DView</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.2.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

This pull request introduces three targeted fixes for DView on macOS when compiling with modern toolchains and running on newer macOS versions.

1. **Compilation with modern wxWidgets**: Fixed deprecated `nrows()`/`ncols()` calls to `Rows()`/`Cols()` and handled a `nullptr` ambiguity issue in `pdfdc.cpp`.
2. **macOS File Open Dialog Issue**: Resolved the silent hang of `wxFileDialog::ShowModal` by properly registering `DView.app` as a macOS Bundle with a unique `gov.nrel.dview` Bundle Identifier, and signing it with `com.apple.security.files.user-selected.*` entitlements automatically during the CMake build process.
3. **Dark Mode Readability**: Updated `wxDVSelectionListCtrl` to dynamically calculate background luminance and enforce high-contrast foreground text and checkboxes, fixing the invisible black-on-dark-grey text issue when macOS is in Dark Mode.