### PR TITLE
Rename NREL throughout code

### DIFF
--- a/src/codeedit.cpp
+++ b/src/codeedit.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/csv.cpp
+++ b/src/csv.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/diurnal.cpp
+++ b/src/diurnal.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvautocolourassigner.cpp
+++ b/src/dview/dvautocolourassigner.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvdcctrl.cpp
+++ b/src/dview/dvdcctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -85,7 +85,7 @@ wxDVDCCtrl::~wxDVDCCtrl() {
 }
 
 void wxDVDCCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -111,7 +111,7 @@ void wxDVDCCtrl::ReadState(std::string filename) {
 }
 
 void wxDVDCCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvdmapctrl.cpp
+++ b/src/dview/dvdmapctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -306,7 +306,7 @@ wxDVDMapCtrl::~wxDVDMapCtrl() {
 }
 
 void wxDVDMapCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -384,7 +384,7 @@ void wxDVDMapCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVDMapCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvfilereader.cpp
+++ b/src/dview/dvfilereader.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -1409,7 +1409,7 @@ bool wxDVFileReader::IsDate(wxString stringToCheck) {
 // Conversion factors from Energy+.idd
 void wxDVFileReader::InitUnitConversions() {
     // NOTE: tuple format (SI unit string, IP unit string, SI to IP conversion factor)
-    // See SetupUnitConversions method in https://github.com/NREL/EnergyPlus/blob/develop/src/EnergyPlus/OutputReportTabular.cc
+    // See SetupUnitConversions method in https://github.com/NatLabRockies/EnergyPlus/blob/develop/src/EnergyPlus/OutputReportTabular.cc
     m_unitConversions.emplace_back("$/(m3/s)", "$/(ft3/min)", 0.000472000059660808);
     m_unitConversions.emplace_back("$/(W/K)", "$/(Btu/h-F)", 0.52667614683731);
     m_unitConversions.emplace_back("$/kW", "$/(kBtuh/h)", 0.293083235638921);

--- a/src/dview/dvplotctrl.cpp
+++ b/src/dview/dvplotctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvplotctrlsettings.cpp
+++ b/src/dview/dvplotctrlsettings.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvplothelper.cpp
+++ b/src/dview/dvplothelper.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvpncdfctrl.cpp
+++ b/src/dview/dvpncdfctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -200,7 +200,7 @@ wxDVPnCdfCtrl::~wxDVPnCdfCtrl() {
 }
 
 void wxDVPnCdfCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -272,7 +272,7 @@ void wxDVPnCdfCtrl::ReadState(std::string filename) {
 }
 
 void wxDVPnCdfCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvprofilectrl.cpp
+++ b/src/dview/dvprofilectrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -202,7 +202,7 @@ wxDVProfileCtrl::wxDVProfileCtrl(wxWindow *parent, wxWindowID id, const wxPoint 
         : wxPanel(parent, id, pos, size, style, name),
           m_timer(nullptr),
           m_counter(0) {
-    //wxFileConfig configFile("DView", "NREL");
+    //wxFileConfig configFile("DView", "NLR");
     m_srchCtrl = NULL;
     wxScrolledWindow *monthSelector = new wxScrolledWindow(this, wxID_ANY,
                                                            wxDefaultPosition, wxDefaultSize, wxHSCROLL);
@@ -279,7 +279,7 @@ wxDVProfileCtrl::~wxDVProfileCtrl() {
 }
 
 void wxDVProfileCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -337,7 +337,7 @@ void wxDVProfileCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVProfileCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvscatterplotctrl.cpp
+++ b/src/dview/dvscatterplotctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -131,7 +131,7 @@ wxDVScatterPlotCtrl::~wxDVScatterPlotCtrl() {
 }
 
 void wxDVScatterPlotCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -182,7 +182,7 @@ void wxDVScatterPlotCtrl::ReadState(std::string filename) {
 }
 
 void wxDVScatterPlotCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvselectionlist.cpp
+++ b/src/dview/dvselectionlist.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/dview/dvstatisticstablectrl.cpp
+++ b/src/dview/dvstatisticstablectrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -452,7 +452,7 @@ wxDVStatisticsTableCtrl::~wxDVStatisticsTableCtrl(void) {
 }
 
 void wxDVStatisticsTableCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     wxString s;
     bool success;
@@ -470,7 +470,7 @@ void wxDVStatisticsTableCtrl::ReadState(std::string filename) {
 }
 
 void wxDVStatisticsTableCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvtimeseriesctrl.cpp
+++ b/src/dview/dvtimeseriesctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -858,12 +858,12 @@ wxDVTimeSeriesCtrl::~wxDVTimeSeriesCtrl(void) {
 }
 
 void wxDVTimeSeriesCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     // Note: on Mac, these settings are stored in a plist file,
     // "DView Preferences" in folder ~/Library/Preferences.
     // On Windows, these settings are stored in the registry
-    // in key HKEY_CURRENT_USER/Software/NREL/DView
+    // in key HKEY_CURRENT_USER/Software/NLR/DView
 
     wxString s;
     bool success;
@@ -984,7 +984,7 @@ void wxDVTimeSeriesCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVTimeSeriesCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NREL");
+    wxConfig cfg("DView", "NLR");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvtimeseriesdataset.cpp
+++ b/src/dview/dvtimeseriesdataset.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/easycurl.cpp
+++ b/src/easycurl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/extgrid.cpp
+++ b/src/extgrid.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/exttext.cpp
+++ b/src/exttext.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/exttextstream.cpp
+++ b/src/exttextstream.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/exttree.cpp
+++ b/src/exttree.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/gleasy.cpp
+++ b/src/gleasy.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/lkscript.cpp
+++ b/src/lkscript.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/metro.cpp
+++ b/src/metro.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/numeric.cpp
+++ b/src/numeric.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/pagelayout.cpp
+++ b/src/pagelayout.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/pageobjects.cpp
+++ b/src/pageobjects.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/mplcontour.cpp
+++ b/src/plot/mplcontour.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plannotation.cpp
+++ b/src/plot/plannotation.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plaxis.cpp
+++ b/src/plot/plaxis.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plbarplot.cpp
+++ b/src/plot/plbarplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plcolourmap.cpp
+++ b/src/plot/plcolourmap.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plcontourplot.cpp
+++ b/src/plot/plcontourplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plhistplot.cpp
+++ b/src/plot/plhistplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/pllineplot.cpp
+++ b/src/plot/pllineplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/ploutdev.cpp
+++ b/src/plot/ploutdev.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plplot.cpp
+++ b/src/plot/plplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plplotctrl.cpp
+++ b/src/plot/plplotctrl.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plscatterplot.cpp
+++ b/src/plot/plscatterplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plsectorplot.cpp
+++ b/src/plot/plsectorplot.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/pltext.cpp
+++ b/src/plot/pltext.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/plot/plwindrose.cpp
+++ b/src/plot/plwindrose.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/radiochoice.cpp
+++ b/src/radiochoice.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -424,7 +424,7 @@ void wxOnlineRegistration::OnRegister(wxCommandEvent &) {
     rapidjson::Document reader;
 
     if (m_register->GetLabel() == "Resend key") {
-        //	https://developer.nrel.gov/api/sam/v1/tracker/resend_key?api_key=SAMAPIKEY&email=someusersemail@somedomain.com
+        //	https://developer.NLR.gov/api/sam/v1/tracker/resend_key?api_key=SAMAPIKEY&email=someusersemail@somedomain.com
         wxString url, post;
         gs_regData->GetApi(wxOnlineRegistrationData::RESEND_KEY, &url, &post);
         curl.SetPostData(post);

--- a/src/registration.cpp
+++ b/src/registration.cpp
@@ -424,7 +424,7 @@ void wxOnlineRegistration::OnRegister(wxCommandEvent &) {
     rapidjson::Document reader;
 
     if (m_register->GetLabel() == "Resend key") {
-        //	https://developer.NLR.gov/api/sam/v1/tracker/resend_key?api_key=SAMAPIKEY&email=someusersemail@somedomain.com
+        //	https://developer.nlr.gov/api/sam/v1/tracker/resend_key?api_key=SAMAPIKEY&email=someusersemail@somedomain.com
         wxString url, post;
         gs_regData->GetApi(wxOnlineRegistrationData::RESEND_KEY, &url, &post);
         curl.SetPostData(post);

--- a/src/snaplay.cpp
+++ b/src/snaplay.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/tpdlg.cpp
+++ b/src/tpdlg.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/uiform.cpp
+++ b/src/uiform.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tools/dview/dview.cpp
+++ b/tools/dview/dview.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -116,7 +116,7 @@ public:
         mPlotCtrl = new wxDVPlotCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
         mPlotCtrl->DisplayTabs();
 
-        wxConfig cfg("DView", "NREL");
+        wxConfig cfg("DView", "NLR");
         long ct = 0;
         if (cfg.Read("RecentCount", &ct))
             mRecentCount = (int) ct;
@@ -262,7 +262,7 @@ public:
 
         long ct = (long) mRecentCount;
 
-        wxConfig cfg("DView", "NREL");
+        wxConfig cfg("DView", "NLR");
         cfg.Write("RecentCount", ct);
         for (int i = 0; i < mRecentCount; i++) {
             wxString key;

--- a/tools/sandbox/sandbox.cpp
+++ b/tools/sandbox/sandbox.cpp
@@ -1,7 +1,7 @@
 /*
 BSD 3-Clause License
 
-Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NREL/wex/blob/develop/LICENSE
+Copyright (c) Alliance for Energy Innovation, LLC. See also https://github.com/NatLabRockies/wex/blob/develop/LICENSE
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Replaces NREL with NLR throughout the code (except in instances where NREL should stay, as in older copyright notices) and updates the Github address in the licenses to NatLabRockies.

@sjanzou I believe the NREL with NLR string replacement within the DView WxConfig calls should be ok, can you please review and confirm?

Goes with pull requests from branches of the same name in ssc, sam, and sam-private.