### PR TITLE
feat: add --ip/--si CLI flags to skip the EnergyPlus units dialog

### DIFF
--- a/include/wex/dview/dvfilereader.h
+++ b/include/wex/dview/dvfilereader.h
@@ -61,14 +61,17 @@ class wxDVFileReader {
 public:
     static void ReadDataFromCSV(wxDVPlotCtrl *plotWin, const wxString &filename, wxChar separator = ',');
 
+    // ipUnits: -1 = ask user (dialog), 0 = SI, 1 = IP
     static bool
-    FastRead(wxDVPlotCtrl *plotWin, const wxString &filename, int prealloc_data = 8760, int prealloc_lnchars = 1024);
+    FastRead(wxDVPlotCtrl *plotWin, const wxString &filename, int prealloc_data = 8760, int prealloc_lnchars = 1024,
+             int ipUnits = -1);
 
     static bool Read8760WFLines(std::vector<wxDVArrayDataSet *> &dataSets, FILE *infile, int wfType);
 
     static bool ReadWeatherFile(wxDVPlotCtrl *plotWin, const wxString &filename);
 
-    static bool ReadSQLFile(wxDVPlotCtrl *plotWin, const wxString &filename);
+    // ipUnits: -1 = ask user (dialog), 0 = SI, 1 = IP
+    static bool ReadSQLFile(wxDVPlotCtrl *plotWin, const wxString &filename, int ipUnits = -1);
 
     static bool IsNumeric(wxString stringToCheck);
 

--- a/src/dview/dvfilereader.cpp
+++ b/src/dview/dvfilereader.cpp
@@ -462,14 +462,15 @@ static bool ReadWeatherFileLine(FILE *fp, int type,
 }
 
 bool
-wxDVFileReader::FastRead(wxDVPlotCtrl *plotWin, const wxString &filename, int prealloc_data, int prealloc_lnchars) {
+wxDVFileReader::FastRead(wxDVPlotCtrl *plotWin, const wxString &filename, int prealloc_data, int prealloc_lnchars,
+                         int ipUnits) {
     wxString fExtension = filename.Right(3);
     if (fExtension.CmpNoCase("tm2") == 0 ||
         fExtension.CmpNoCase("epw") == 0 ||
         fExtension.CmpNoCase("smw") == 0) {
         return ReadWeatherFile(plotWin, filename);
     } else if (fExtension.CmpNoCase("sql") == 0) {
-        return ReadSQLFile(plotWin, filename);
+        return ReadSQLFile(plotWin, filename, ipUnits);
     }
 
     wxStopWatch sw;
@@ -933,7 +934,7 @@ bool wxDVFileReader::Read8760WFLines(std::vector<wxDVArrayDataSet *> &dataSets, 
     return true;
 }
 
-bool wxDVFileReader::ReadSQLFile(wxDVPlotCtrl *plotWin, const wxString &filename) {
+bool wxDVFileReader::ReadSQLFile(wxDVPlotCtrl *plotWin, const wxString &filename, int ipUnits) {
     wxFileName fileName(filename);
 
     if (!fileName.IsFileReadable()) {
@@ -945,8 +946,13 @@ bool wxDVFileReader::ReadSQLFile(wxDVPlotCtrl *plotWin, const wxString &filename
     int success = sqlite3_open_v2(filename.c_str(), &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_EXCLUSIVE, nullptr);
 
     if (success == SQLITE_OK) {
-        int convertUnits = wxMessageBox(wxT("Would you like to display your Energy+ data in IP units?."),
+        int convertUnits;
+        if (ipUnits < 0) {
+            convertUnits = wxMessageBox(wxT("Would you like to display your Energy+ data in IP units?."),
                                         wxT("Units Conversion"), wxYES_NO);
+        } else {
+            convertUnits = ipUnits ? wxYES : wxNO;
+        }
 
         wxStopWatch sw;
         sw.Start();

--- a/tools/dview/dview.cpp
+++ b/tools/dview/dview.cpp
@@ -280,7 +280,7 @@ public:
         Destroy();
     }
 
-    bool Load(const wxArrayString &filenames) {
+    bool Load(const wxArrayString &filenames, int ipUnits = -1) {
         bool FileExists = false;
 
         wxBeginBusyCursor();
@@ -294,7 +294,7 @@ public:
             }
 
             if (!FileExists) {
-                if (!wxDVFileReader::FastRead(mPlotCtrl, filenames[i])) {
+                if (!wxDVFileReader::FastRead(mPlotCtrl, filenames[i], 8760, 1024, ipUnits)) {
                     wxMessageBox(
                             wxT("The selected file is not of the correct format, is corrupt, no longer exists, or you do not have permission to open it."),
                             wxT("Error opening file."), wxICON_ERROR);
@@ -378,6 +378,7 @@ private:
 
     bool m_arg_showLog;
     int m_arg_tab, m_arg_data;
+    int m_arg_ipUnits;  // -1 = ask (dialog), 0 = SI, 1 = IP
     double m_startHour, m_endHour;
     wxArrayString m_variables;
     wxArrayString m_arg_filenames;
@@ -399,7 +400,7 @@ public:
         DViewFrame *frame = new DViewFrame;
 
         if (m_arg_filenames.Count() > 0)
-            frame->Load(m_arg_filenames);
+            frame->Load(m_arg_filenames, m_arg_ipUnits);
 
         if (m_arg_tab != -1)
             frame->GetPlot()->SelectTabIndex(m_arg_tab);
@@ -448,6 +449,8 @@ public:
                          wxCMD_LINE_VAL_STRING);
         parser.AddParam(wxT("files to load"), wxCMD_LINE_VAL_STRING,
                         wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
+        parser.AddSwitch(wxT(""), wxT("ip"), wxT("display Energy+ SQL data in IP units (skips dialog)"));
+        parser.AddSwitch(wxT(""), wxT("si"), wxT("display Energy+ SQL data in SI units (skips dialog)"));
     }
 
     bool OnCmdLineParsed(wxCmdLineParser &parser) {
@@ -463,6 +466,12 @@ public:
             m_arg_showLog = true;
         else
             m_arg_showLog = false;
+
+        m_arg_ipUnits = -1;
+        if (parser.Found(wxT("ip")))
+            m_arg_ipUnits = 1;
+        else if (parser.Found(wxT("si")))
+            m_arg_ipUnits = 0;
 
         m_arg_tab = -1;
         if (parser.Found(wxT("t"), &tabNumber) && tabNumber >= 0)


### PR DESCRIPTION
## Summary

- Adds `--ip` and `--si` long switches to the `dview` command-line tool
- When either flag is present, DView skips the interactive *"Would you like to display your Energy+ data in IP units?"* dialog and uses the supplied preference directly
- When neither flag is given, the existing dialog behaviour is preserved (fully backward-compatible)

## Motivation

[OpenStudio Application PR #873](https://github.com/openstudiocoalition/OpenStudioApplication/pull/873) adds comprehensive i18n/translation support to the OpenStudio GUI. One outstanding gap is the DView *Units Conversion* dialog — it is rendered by the `dviewx64.exe` binary (wxWidgets) and therefore cannot be translated through Qt's `.ts` system.

The proposed solution is for OpenStudio to show its own translated Qt dialog asking the user about units, then forward the answer to DView via CLI flag, bypassing DView's English-only prompt entirely.

## Changes

| File | Change |
|---|---|
| `include/wex/dview/dvfilereader.h` | Added `int ipUnits = -1` parameter to `FastRead` and `ReadSQLFile` declarations |
| `src/dview/dvfilereader.cpp` | `ReadSQLFile`: shows dialog only when `ipUnits < 0`; otherwise maps `1→wxYES`, `0→wxNO`. `FastRead`: passes `ipUnits` through to `ReadSQLFile`. |
| `tools/dview/dview.cpp` | Added `m_arg_ipUnits` member; registered `--ip` / `--si` switches in `OnInitCmdLine`; parsed in `OnCmdLineParsed`; forwarded via `frame->Load(filenames, ipUnits)` |

## Backward compatibility

All new parameters default to `-1` (ask via dialog), so existing callers that do not pass the argument get identical behaviour to today.

## Test plan

- [ ] `dview file.sql` — dialog still appears as before
- [ ] `dview --ip file.sql` — no dialog, data loads in IP units
- [ ] `dview --si file.sql` — no dialog, data loads in SI units
- [ ] Passing both `--ip` and `--si` — `--ip` wins (first match wins in `OnCmdLineParsed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)