### PR TITLE
Reverts wxConfig to NREL for backward compatibility

### DIFF
--- a/src/dview/dvdcctrl.cpp
+++ b/src/dview/dvdcctrl.cpp
@@ -85,7 +85,7 @@ wxDVDCCtrl::~wxDVDCCtrl() {
 }
 
 void wxDVDCCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -111,7 +111,7 @@ void wxDVDCCtrl::ReadState(std::string filename) {
 }
 
 void wxDVDCCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvdmapctrl.cpp
+++ b/src/dview/dvdmapctrl.cpp
@@ -306,7 +306,7 @@ wxDVDMapCtrl::~wxDVDMapCtrl() {
 }
 
 void wxDVDMapCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -384,7 +384,7 @@ void wxDVDMapCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVDMapCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvpncdfctrl.cpp
+++ b/src/dview/dvpncdfctrl.cpp
@@ -200,7 +200,7 @@ wxDVPnCdfCtrl::~wxDVPnCdfCtrl() {
 }
 
 void wxDVPnCdfCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -272,7 +272,7 @@ void wxDVPnCdfCtrl::ReadState(std::string filename) {
 }
 
 void wxDVPnCdfCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvprofilectrl.cpp
+++ b/src/dview/dvprofilectrl.cpp
@@ -279,7 +279,7 @@ wxDVProfileCtrl::~wxDVProfileCtrl() {
 }
 
 void wxDVProfileCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -337,7 +337,7 @@ void wxDVProfileCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVProfileCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvscatterplotctrl.cpp
+++ b/src/dview/dvscatterplotctrl.cpp
@@ -131,7 +131,7 @@ wxDVScatterPlotCtrl::~wxDVScatterPlotCtrl() {
 }
 
 void wxDVScatterPlotCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -182,7 +182,7 @@ void wxDVScatterPlotCtrl::ReadState(std::string filename) {
 }
 
 void wxDVScatterPlotCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvstatisticstablectrl.cpp
+++ b/src/dview/dvstatisticstablectrl.cpp
@@ -452,7 +452,7 @@ wxDVStatisticsTableCtrl::~wxDVStatisticsTableCtrl(void) {
 }
 
 void wxDVStatisticsTableCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     wxString s;
     bool success;
@@ -470,7 +470,7 @@ void wxDVStatisticsTableCtrl::ReadState(std::string filename) {
 }
 
 void wxDVStatisticsTableCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/src/dview/dvtimeseriesctrl.cpp
+++ b/src/dview/dvtimeseriesctrl.cpp
@@ -858,7 +858,7 @@ wxDVTimeSeriesCtrl::~wxDVTimeSeriesCtrl(void) {
 }
 
 void wxDVTimeSeriesCtrl::ReadState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     // Note: on Mac, these settings are stored in a plist file,
     // "DView Preferences" in folder ~/Library/Preferences.
@@ -984,7 +984,7 @@ void wxDVTimeSeriesCtrl::OnTimer(wxTimerEvent &) {
 }
 
 void wxDVTimeSeriesCtrl::WriteState(std::string filename) {
-    wxConfig cfg("DView", "NLR");
+    wxConfig cfg("DView", "NREL");
 
     bool success;
     bool debugging = false;

--- a/tools/dview/dview.cpp
+++ b/tools/dview/dview.cpp
@@ -116,7 +116,7 @@ public:
         mPlotCtrl = new wxDVPlotCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
         mPlotCtrl->DisplayTabs();
 
-        wxConfig cfg("DView", "NLR");
+        wxConfig cfg("DView", "NREL");
         long ct = 0;
         if (cfg.Read("RecentCount", &ct))
             mRecentCount = (int) ct;
@@ -262,7 +262,7 @@ public:
 
         long ct = (long) mRecentCount;
 
-        wxConfig cfg("DView", "NLR");
+        wxConfig cfg("DView", "NREL");
         cfg.Write("RecentCount", ct);
         for (int i = 0; i < mRecentCount; i++) {
             wxString key;


### PR DESCRIPTION
This avoids issue with information written to Windows registry and Mac/Linux config files not being correctly loaded for 2026 versions of SAM/DView and later.

An alternative approach would be to add a condition when "NREL" entries in the Windows registry or Mac/Linux configuration files exist to read them and copy them to new "NLR" entries. The alternative approach would require more time and testing to implement than this simple approach of preserving the "NREL" entries.

This goes with:

* https://github.com/NatLabRockies/SAM/pull/2225

* https://github.com/NatLabRockies/SAM-private/pull/161

I forgot to include this WEX repository when I made those PRs.
